### PR TITLE
perf(docker): improve pd/store/server image build cache efficiency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,73 @@
+# Keep this aligned with .gitignore first to avoid duplicate drift.
+
+# VCS and CI metadata
+.git
+.github/
+.svn/
+
+# IDE and local assistant metadata
+.idea/
+.vscode/
+.serena/
+CLAUDE.md
+CLAUDE_*.md
+GEMINI.md
+copilot-instructions.md
+.copilot-instructions.md
+cursor-instructions.md
+.cursor-instructions.md
+cursor.md
+windsurf.md
+windsurf-instructions.md
+codeium.md
+codeium-instructions.md
+.ai-instructions.md
+*.ai-prompt.md
+WARP.md
+
+# Build outputs and local data
+**/target/
+**/build/
+**/node_modules/
+hugegraph-server/hugegraph-dist/docker/data/
+**/pd_data/
+**/storage/
+upload-files/
+output/
+apache-hugegraph-*/
+
+# Local temp and editor files
+.DS_Store
+*/.DS_Store
+**/*.DS_Store
+Thumbs.db
+*.orig
+*.rej
+*.diff
+*.patch
+*.tmp
+*.cache
+*.swp
+*.log
+*.pyc
+*.sdf
+*.suo
+*.vcxproj.user
+
+# Java/IDE project files
+.apt_generated/
+.classpath
+.factorypath
+.project
+.settings/
+.springBeans
+.sts4-cache/
+*.iws
+*.iml
+*.ipr
+
+# Repo files that do not affect image contents
+/docker/
+/BUILDING.md
+/CONTRIBUTING.md
+/README.md

--- a/hugegraph-pd/Dockerfile
+++ b/hugegraph-pd/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -19,11 +21,68 @@
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
-COPY . /pkg
 WORKDIR /pkg
 ARG MAVEN_ARGS
 
-RUN mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
+COPY pom.xml ./
+COPY hugegraph-cluster-test/pom.xml ./hugegraph-cluster-test/pom.xml
+COPY hugegraph-cluster-test/hugegraph-clustertest-dist/pom.xml ./hugegraph-cluster-test/hugegraph-clustertest-dist/pom.xml
+COPY hugegraph-cluster-test/hugegraph-clustertest-minicluster/pom.xml ./hugegraph-cluster-test/hugegraph-clustertest-minicluster/pom.xml
+COPY hugegraph-cluster-test/hugegraph-clustertest-test/pom.xml ./hugegraph-cluster-test/hugegraph-clustertest-test/pom.xml
+COPY hugegraph-commons/pom.xml ./hugegraph-commons/pom.xml
+COPY hugegraph-commons/hugegraph-common/pom.xml ./hugegraph-commons/hugegraph-common/pom.xml
+COPY hugegraph-commons/hugegraph-rpc/pom.xml ./hugegraph-commons/hugegraph-rpc/pom.xml
+COPY hugegraph-pd/pom.xml ./hugegraph-pd/pom.xml
+COPY hugegraph-pd/hg-pd-cli/pom.xml ./hugegraph-pd/hg-pd-cli/pom.xml
+COPY hugegraph-pd/hg-pd-client/pom.xml ./hugegraph-pd/hg-pd-client/pom.xml
+COPY hugegraph-pd/hg-pd-common/pom.xml ./hugegraph-pd/hg-pd-common/pom.xml
+COPY hugegraph-pd/hg-pd-core/pom.xml ./hugegraph-pd/hg-pd-core/pom.xml
+COPY hugegraph-pd/hg-pd-dist/pom.xml ./hugegraph-pd/hg-pd-dist/pom.xml
+COPY hugegraph-pd/hg-pd-grpc/pom.xml ./hugegraph-pd/hg-pd-grpc/pom.xml
+COPY hugegraph-pd/hg-pd-service/pom.xml ./hugegraph-pd/hg-pd-service/pom.xml
+COPY hugegraph-pd/hg-pd-test/pom.xml ./hugegraph-pd/hg-pd-test/pom.xml
+COPY hugegraph-server/pom.xml ./hugegraph-server/pom.xml
+COPY hugegraph-server/hugegraph-api/pom.xml ./hugegraph-server/hugegraph-api/pom.xml
+COPY hugegraph-server/hugegraph-cassandra/pom.xml ./hugegraph-server/hugegraph-cassandra/pom.xml
+COPY hugegraph-server/hugegraph-core/pom.xml ./hugegraph-server/hugegraph-core/pom.xml
+COPY hugegraph-server/hugegraph-dist/pom.xml ./hugegraph-server/hugegraph-dist/pom.xml
+COPY hugegraph-server/hugegraph-example/pom.xml ./hugegraph-server/hugegraph-example/pom.xml
+COPY hugegraph-server/hugegraph-hbase/pom.xml ./hugegraph-server/hugegraph-hbase/pom.xml
+COPY hugegraph-server/hugegraph-hstore/pom.xml ./hugegraph-server/hugegraph-hstore/pom.xml
+COPY hugegraph-server/hugegraph-mysql/pom.xml ./hugegraph-server/hugegraph-mysql/pom.xml
+COPY hugegraph-server/hugegraph-palo/pom.xml ./hugegraph-server/hugegraph-palo/pom.xml
+COPY hugegraph-server/hugegraph-postgresql/pom.xml ./hugegraph-server/hugegraph-postgresql/pom.xml
+COPY hugegraph-server/hugegraph-rocksdb/pom.xml ./hugegraph-server/hugegraph-rocksdb/pom.xml
+COPY hugegraph-server/hugegraph-scylladb/pom.xml ./hugegraph-server/hugegraph-scylladb/pom.xml
+COPY hugegraph-server/hugegraph-test/pom.xml ./hugegraph-server/hugegraph-test/pom.xml
+COPY hugegraph-store/pom.xml ./hugegraph-store/pom.xml
+COPY hugegraph-store/hg-store-cli/pom.xml ./hugegraph-store/hg-store-cli/pom.xml
+COPY hugegraph-store/hg-store-client/pom.xml ./hugegraph-store/hg-store-client/pom.xml
+COPY hugegraph-store/hg-store-common/pom.xml ./hugegraph-store/hg-store-common/pom.xml
+COPY hugegraph-store/hg-store-core/pom.xml ./hugegraph-store/hg-store-core/pom.xml
+COPY hugegraph-store/hg-store-dist/pom.xml ./hugegraph-store/hg-store-dist/pom.xml
+COPY hugegraph-store/hg-store-grpc/pom.xml ./hugegraph-store/hg-store-grpc/pom.xml
+COPY hugegraph-store/hg-store-node/pom.xml ./hugegraph-store/hg-store-node/pom.xml
+COPY hugegraph-store/hg-store-rocksdb/pom.xml ./hugegraph-store/hg-store-rocksdb/pom.xml
+COPY hugegraph-store/hg-store-test/pom.xml ./hugegraph-store/hg-store-test/pom.xml
+COPY hugegraph-struct/pom.xml ./hugegraph-struct/pom.xml
+COPY install-dist/pom.xml ./install-dist/pom.xml
+
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn dependency:go-offline $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
+
+COPY LICENSE NOTICE ./
+COPY style ./style
+COPY hugegraph-cluster-test ./hugegraph-cluster-test
+COPY hugegraph-commons ./hugegraph-commons
+COPY hugegraph-pd ./hugegraph-pd
+COPY hugegraph-server ./hugegraph-server
+COPY hugegraph-store ./hugegraph-store
+COPY hugegraph-struct ./hugegraph-struct
+COPY install-dist ./install-dist
+
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
     ./hugegraph-server/*.tar.gz && rm ./hugegraph-pd/*.tar.gz && rm ./hugegraph-store/*.tar.gz
 
 # 2nd stage: runtime env

--- a/hugegraph-server/Dockerfile
+++ b/hugegraph-server/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -19,11 +21,68 @@
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
-COPY . /pkg
 WORKDIR /pkg
 ARG MAVEN_ARGS
 
-RUN mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
+COPY pom.xml ./
+COPY hugegraph-cluster-test/pom.xml ./hugegraph-cluster-test/pom.xml
+COPY hugegraph-cluster-test/hugegraph-clustertest-dist/pom.xml ./hugegraph-cluster-test/hugegraph-clustertest-dist/pom.xml
+COPY hugegraph-cluster-test/hugegraph-clustertest-minicluster/pom.xml ./hugegraph-cluster-test/hugegraph-clustertest-minicluster/pom.xml
+COPY hugegraph-cluster-test/hugegraph-clustertest-test/pom.xml ./hugegraph-cluster-test/hugegraph-clustertest-test/pom.xml
+COPY hugegraph-commons/pom.xml ./hugegraph-commons/pom.xml
+COPY hugegraph-commons/hugegraph-common/pom.xml ./hugegraph-commons/hugegraph-common/pom.xml
+COPY hugegraph-commons/hugegraph-rpc/pom.xml ./hugegraph-commons/hugegraph-rpc/pom.xml
+COPY hugegraph-pd/pom.xml ./hugegraph-pd/pom.xml
+COPY hugegraph-pd/hg-pd-cli/pom.xml ./hugegraph-pd/hg-pd-cli/pom.xml
+COPY hugegraph-pd/hg-pd-client/pom.xml ./hugegraph-pd/hg-pd-client/pom.xml
+COPY hugegraph-pd/hg-pd-common/pom.xml ./hugegraph-pd/hg-pd-common/pom.xml
+COPY hugegraph-pd/hg-pd-core/pom.xml ./hugegraph-pd/hg-pd-core/pom.xml
+COPY hugegraph-pd/hg-pd-dist/pom.xml ./hugegraph-pd/hg-pd-dist/pom.xml
+COPY hugegraph-pd/hg-pd-grpc/pom.xml ./hugegraph-pd/hg-pd-grpc/pom.xml
+COPY hugegraph-pd/hg-pd-service/pom.xml ./hugegraph-pd/hg-pd-service/pom.xml
+COPY hugegraph-pd/hg-pd-test/pom.xml ./hugegraph-pd/hg-pd-test/pom.xml
+COPY hugegraph-server/pom.xml ./hugegraph-server/pom.xml
+COPY hugegraph-server/hugegraph-api/pom.xml ./hugegraph-server/hugegraph-api/pom.xml
+COPY hugegraph-server/hugegraph-cassandra/pom.xml ./hugegraph-server/hugegraph-cassandra/pom.xml
+COPY hugegraph-server/hugegraph-core/pom.xml ./hugegraph-server/hugegraph-core/pom.xml
+COPY hugegraph-server/hugegraph-dist/pom.xml ./hugegraph-server/hugegraph-dist/pom.xml
+COPY hugegraph-server/hugegraph-example/pom.xml ./hugegraph-server/hugegraph-example/pom.xml
+COPY hugegraph-server/hugegraph-hbase/pom.xml ./hugegraph-server/hugegraph-hbase/pom.xml
+COPY hugegraph-server/hugegraph-hstore/pom.xml ./hugegraph-server/hugegraph-hstore/pom.xml
+COPY hugegraph-server/hugegraph-mysql/pom.xml ./hugegraph-server/hugegraph-mysql/pom.xml
+COPY hugegraph-server/hugegraph-palo/pom.xml ./hugegraph-server/hugegraph-palo/pom.xml
+COPY hugegraph-server/hugegraph-postgresql/pom.xml ./hugegraph-server/hugegraph-postgresql/pom.xml
+COPY hugegraph-server/hugegraph-rocksdb/pom.xml ./hugegraph-server/hugegraph-rocksdb/pom.xml
+COPY hugegraph-server/hugegraph-scylladb/pom.xml ./hugegraph-server/hugegraph-scylladb/pom.xml
+COPY hugegraph-server/hugegraph-test/pom.xml ./hugegraph-server/hugegraph-test/pom.xml
+COPY hugegraph-store/pom.xml ./hugegraph-store/pom.xml
+COPY hugegraph-store/hg-store-cli/pom.xml ./hugegraph-store/hg-store-cli/pom.xml
+COPY hugegraph-store/hg-store-client/pom.xml ./hugegraph-store/hg-store-client/pom.xml
+COPY hugegraph-store/hg-store-common/pom.xml ./hugegraph-store/hg-store-common/pom.xml
+COPY hugegraph-store/hg-store-core/pom.xml ./hugegraph-store/hg-store-core/pom.xml
+COPY hugegraph-store/hg-store-dist/pom.xml ./hugegraph-store/hg-store-dist/pom.xml
+COPY hugegraph-store/hg-store-grpc/pom.xml ./hugegraph-store/hg-store-grpc/pom.xml
+COPY hugegraph-store/hg-store-node/pom.xml ./hugegraph-store/hg-store-node/pom.xml
+COPY hugegraph-store/hg-store-rocksdb/pom.xml ./hugegraph-store/hg-store-rocksdb/pom.xml
+COPY hugegraph-store/hg-store-test/pom.xml ./hugegraph-store/hg-store-test/pom.xml
+COPY hugegraph-struct/pom.xml ./hugegraph-struct/pom.xml
+COPY install-dist/pom.xml ./install-dist/pom.xml
+
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn dependency:go-offline $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
+
+COPY LICENSE NOTICE ./
+COPY style ./style
+COPY hugegraph-cluster-test ./hugegraph-cluster-test
+COPY hugegraph-commons ./hugegraph-commons
+COPY hugegraph-pd ./hugegraph-pd
+COPY hugegraph-server ./hugegraph-server
+COPY hugegraph-store ./hugegraph-store
+COPY hugegraph-struct ./hugegraph-struct
+COPY install-dist ./install-dist
+
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
     ./hugegraph-server/*.tar.gz && rm ./hugegraph-pd/*.tar.gz && rm ./hugegraph-store/*.tar.gz
 
 # 2nd stage: runtime env

--- a/hugegraph-server/Dockerfile-hstore
+++ b/hugegraph-server/Dockerfile-hstore
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -19,11 +21,68 @@
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
-COPY . /pkg
 WORKDIR /pkg
 ARG MAVEN_ARGS
 
-RUN mvn package $MAVEN_ARGS -e -B -ntp -DskipTests -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
+COPY pom.xml ./
+COPY hugegraph-cluster-test/pom.xml ./hugegraph-cluster-test/pom.xml
+COPY hugegraph-cluster-test/hugegraph-clustertest-dist/pom.xml ./hugegraph-cluster-test/hugegraph-clustertest-dist/pom.xml
+COPY hugegraph-cluster-test/hugegraph-clustertest-minicluster/pom.xml ./hugegraph-cluster-test/hugegraph-clustertest-minicluster/pom.xml
+COPY hugegraph-cluster-test/hugegraph-clustertest-test/pom.xml ./hugegraph-cluster-test/hugegraph-clustertest-test/pom.xml
+COPY hugegraph-commons/pom.xml ./hugegraph-commons/pom.xml
+COPY hugegraph-commons/hugegraph-common/pom.xml ./hugegraph-commons/hugegraph-common/pom.xml
+COPY hugegraph-commons/hugegraph-rpc/pom.xml ./hugegraph-commons/hugegraph-rpc/pom.xml
+COPY hugegraph-pd/pom.xml ./hugegraph-pd/pom.xml
+COPY hugegraph-pd/hg-pd-cli/pom.xml ./hugegraph-pd/hg-pd-cli/pom.xml
+COPY hugegraph-pd/hg-pd-client/pom.xml ./hugegraph-pd/hg-pd-client/pom.xml
+COPY hugegraph-pd/hg-pd-common/pom.xml ./hugegraph-pd/hg-pd-common/pom.xml
+COPY hugegraph-pd/hg-pd-core/pom.xml ./hugegraph-pd/hg-pd-core/pom.xml
+COPY hugegraph-pd/hg-pd-dist/pom.xml ./hugegraph-pd/hg-pd-dist/pom.xml
+COPY hugegraph-pd/hg-pd-grpc/pom.xml ./hugegraph-pd/hg-pd-grpc/pom.xml
+COPY hugegraph-pd/hg-pd-service/pom.xml ./hugegraph-pd/hg-pd-service/pom.xml
+COPY hugegraph-pd/hg-pd-test/pom.xml ./hugegraph-pd/hg-pd-test/pom.xml
+COPY hugegraph-server/pom.xml ./hugegraph-server/pom.xml
+COPY hugegraph-server/hugegraph-api/pom.xml ./hugegraph-server/hugegraph-api/pom.xml
+COPY hugegraph-server/hugegraph-cassandra/pom.xml ./hugegraph-server/hugegraph-cassandra/pom.xml
+COPY hugegraph-server/hugegraph-core/pom.xml ./hugegraph-server/hugegraph-core/pom.xml
+COPY hugegraph-server/hugegraph-dist/pom.xml ./hugegraph-server/hugegraph-dist/pom.xml
+COPY hugegraph-server/hugegraph-example/pom.xml ./hugegraph-server/hugegraph-example/pom.xml
+COPY hugegraph-server/hugegraph-hbase/pom.xml ./hugegraph-server/hugegraph-hbase/pom.xml
+COPY hugegraph-server/hugegraph-hstore/pom.xml ./hugegraph-server/hugegraph-hstore/pom.xml
+COPY hugegraph-server/hugegraph-mysql/pom.xml ./hugegraph-server/hugegraph-mysql/pom.xml
+COPY hugegraph-server/hugegraph-palo/pom.xml ./hugegraph-server/hugegraph-palo/pom.xml
+COPY hugegraph-server/hugegraph-postgresql/pom.xml ./hugegraph-server/hugegraph-postgresql/pom.xml
+COPY hugegraph-server/hugegraph-rocksdb/pom.xml ./hugegraph-server/hugegraph-rocksdb/pom.xml
+COPY hugegraph-server/hugegraph-scylladb/pom.xml ./hugegraph-server/hugegraph-scylladb/pom.xml
+COPY hugegraph-server/hugegraph-test/pom.xml ./hugegraph-server/hugegraph-test/pom.xml
+COPY hugegraph-store/pom.xml ./hugegraph-store/pom.xml
+COPY hugegraph-store/hg-store-cli/pom.xml ./hugegraph-store/hg-store-cli/pom.xml
+COPY hugegraph-store/hg-store-client/pom.xml ./hugegraph-store/hg-store-client/pom.xml
+COPY hugegraph-store/hg-store-common/pom.xml ./hugegraph-store/hg-store-common/pom.xml
+COPY hugegraph-store/hg-store-core/pom.xml ./hugegraph-store/hg-store-core/pom.xml
+COPY hugegraph-store/hg-store-dist/pom.xml ./hugegraph-store/hg-store-dist/pom.xml
+COPY hugegraph-store/hg-store-grpc/pom.xml ./hugegraph-store/hg-store-grpc/pom.xml
+COPY hugegraph-store/hg-store-node/pom.xml ./hugegraph-store/hg-store-node/pom.xml
+COPY hugegraph-store/hg-store-rocksdb/pom.xml ./hugegraph-store/hg-store-rocksdb/pom.xml
+COPY hugegraph-store/hg-store-test/pom.xml ./hugegraph-store/hg-store-test/pom.xml
+COPY hugegraph-struct/pom.xml ./hugegraph-struct/pom.xml
+COPY install-dist/pom.xml ./install-dist/pom.xml
+
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn dependency:go-offline $MAVEN_ARGS -e -B -ntp -DskipTests -Dmaven.javadoc.skip=true
+
+COPY LICENSE NOTICE ./
+COPY style ./style
+COPY hugegraph-cluster-test ./hugegraph-cluster-test
+COPY hugegraph-commons ./hugegraph-commons
+COPY hugegraph-pd ./hugegraph-pd
+COPY hugegraph-server ./hugegraph-server
+COPY hugegraph-store ./hugegraph-store
+COPY hugegraph-struct ./hugegraph-struct
+COPY install-dist ./install-dist
+
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn package $MAVEN_ARGS -e -B -ntp -DskipTests -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
     ./hugegraph-server/*.tar.gz && rm ./hugegraph-pd/*.tar.gz && rm ./hugegraph-store/*.tar.gz
 
 # 2nd stage: runtime env

--- a/hugegraph-store/Dockerfile
+++ b/hugegraph-store/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -19,11 +21,68 @@
 # 1st stage: build source code
 FROM maven:3.9.0-eclipse-temurin-11 AS build
 
-COPY . /pkg
 WORKDIR /pkg
 ARG MAVEN_ARGS
 
-RUN mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
+COPY pom.xml ./
+COPY hugegraph-cluster-test/pom.xml ./hugegraph-cluster-test/pom.xml
+COPY hugegraph-cluster-test/hugegraph-clustertest-dist/pom.xml ./hugegraph-cluster-test/hugegraph-clustertest-dist/pom.xml
+COPY hugegraph-cluster-test/hugegraph-clustertest-minicluster/pom.xml ./hugegraph-cluster-test/hugegraph-clustertest-minicluster/pom.xml
+COPY hugegraph-cluster-test/hugegraph-clustertest-test/pom.xml ./hugegraph-cluster-test/hugegraph-clustertest-test/pom.xml
+COPY hugegraph-commons/pom.xml ./hugegraph-commons/pom.xml
+COPY hugegraph-commons/hugegraph-common/pom.xml ./hugegraph-commons/hugegraph-common/pom.xml
+COPY hugegraph-commons/hugegraph-rpc/pom.xml ./hugegraph-commons/hugegraph-rpc/pom.xml
+COPY hugegraph-pd/pom.xml ./hugegraph-pd/pom.xml
+COPY hugegraph-pd/hg-pd-cli/pom.xml ./hugegraph-pd/hg-pd-cli/pom.xml
+COPY hugegraph-pd/hg-pd-client/pom.xml ./hugegraph-pd/hg-pd-client/pom.xml
+COPY hugegraph-pd/hg-pd-common/pom.xml ./hugegraph-pd/hg-pd-common/pom.xml
+COPY hugegraph-pd/hg-pd-core/pom.xml ./hugegraph-pd/hg-pd-core/pom.xml
+COPY hugegraph-pd/hg-pd-dist/pom.xml ./hugegraph-pd/hg-pd-dist/pom.xml
+COPY hugegraph-pd/hg-pd-grpc/pom.xml ./hugegraph-pd/hg-pd-grpc/pom.xml
+COPY hugegraph-pd/hg-pd-service/pom.xml ./hugegraph-pd/hg-pd-service/pom.xml
+COPY hugegraph-pd/hg-pd-test/pom.xml ./hugegraph-pd/hg-pd-test/pom.xml
+COPY hugegraph-server/pom.xml ./hugegraph-server/pom.xml
+COPY hugegraph-server/hugegraph-api/pom.xml ./hugegraph-server/hugegraph-api/pom.xml
+COPY hugegraph-server/hugegraph-cassandra/pom.xml ./hugegraph-server/hugegraph-cassandra/pom.xml
+COPY hugegraph-server/hugegraph-core/pom.xml ./hugegraph-server/hugegraph-core/pom.xml
+COPY hugegraph-server/hugegraph-dist/pom.xml ./hugegraph-server/hugegraph-dist/pom.xml
+COPY hugegraph-server/hugegraph-example/pom.xml ./hugegraph-server/hugegraph-example/pom.xml
+COPY hugegraph-server/hugegraph-hbase/pom.xml ./hugegraph-server/hugegraph-hbase/pom.xml
+COPY hugegraph-server/hugegraph-hstore/pom.xml ./hugegraph-server/hugegraph-hstore/pom.xml
+COPY hugegraph-server/hugegraph-mysql/pom.xml ./hugegraph-server/hugegraph-mysql/pom.xml
+COPY hugegraph-server/hugegraph-palo/pom.xml ./hugegraph-server/hugegraph-palo/pom.xml
+COPY hugegraph-server/hugegraph-postgresql/pom.xml ./hugegraph-server/hugegraph-postgresql/pom.xml
+COPY hugegraph-server/hugegraph-rocksdb/pom.xml ./hugegraph-server/hugegraph-rocksdb/pom.xml
+COPY hugegraph-server/hugegraph-scylladb/pom.xml ./hugegraph-server/hugegraph-scylladb/pom.xml
+COPY hugegraph-server/hugegraph-test/pom.xml ./hugegraph-server/hugegraph-test/pom.xml
+COPY hugegraph-store/pom.xml ./hugegraph-store/pom.xml
+COPY hugegraph-store/hg-store-cli/pom.xml ./hugegraph-store/hg-store-cli/pom.xml
+COPY hugegraph-store/hg-store-client/pom.xml ./hugegraph-store/hg-store-client/pom.xml
+COPY hugegraph-store/hg-store-common/pom.xml ./hugegraph-store/hg-store-common/pom.xml
+COPY hugegraph-store/hg-store-core/pom.xml ./hugegraph-store/hg-store-core/pom.xml
+COPY hugegraph-store/hg-store-dist/pom.xml ./hugegraph-store/hg-store-dist/pom.xml
+COPY hugegraph-store/hg-store-grpc/pom.xml ./hugegraph-store/hg-store-grpc/pom.xml
+COPY hugegraph-store/hg-store-node/pom.xml ./hugegraph-store/hg-store-node/pom.xml
+COPY hugegraph-store/hg-store-rocksdb/pom.xml ./hugegraph-store/hg-store-rocksdb/pom.xml
+COPY hugegraph-store/hg-store-test/pom.xml ./hugegraph-store/hg-store-test/pom.xml
+COPY hugegraph-struct/pom.xml ./hugegraph-struct/pom.xml
+COPY install-dist/pom.xml ./install-dist/pom.xml
+
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn dependency:go-offline $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
+
+COPY LICENSE NOTICE ./
+COPY style ./style
+COPY hugegraph-cluster-test ./hugegraph-cluster-test
+COPY hugegraph-commons ./hugegraph-commons
+COPY hugegraph-pd ./hugegraph-pd
+COPY hugegraph-server ./hugegraph-server
+COPY hugegraph-store ./hugegraph-store
+COPY hugegraph-struct ./hugegraph-struct
+COPY install-dist ./install-dist
+
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn package $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true && pwd && ls -l && rm \
     ./hugegraph-server/*.tar.gz && rm ./hugegraph-pd/*.tar.gz && rm ./hugegraph-store/*.tar.gz
 
 # 2nd stage: runtime env


### PR DESCRIPTION
## Purpose of the PR

- close #2977
- Improve Docker build cache efficiency for pd/store/server images in Phase A scope without changing runtime behavior.
- Reduce unnecessary cache invalidation caused by broad source copying and reuse Maven dependencies/layers more effectively across repeated builds.

## Main Changes

- Added a root `.dockerignore` to exclude cache-noisy files that should not affect Docker image builds, while keeping required Maven module sources in the build context.
- Refactored `hugegraph-pd/Dockerfile`, `hugegraph-store/Dockerfile`, `hugegraph-server/Dockerfile`, and `hugegraph-server/Dockerfile-hstore` to copy dependency-related `pom.xml` files before copying the full source tree.
- Added BuildKit Maven cache mounts with `--mount=type=cache,target=/root/.m2` for both dependency resolution and package steps.
- Kept existing runtime image behavior unchanged, including entrypoints, ports, and container startup flow.
- During validation, narrowed an overly broad `.dockerignore` rule so Maven module directories such as `hugegraph-server/hugegraph-dist` remain included in the Docker build context.

## Verifying these changes

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - Build all four images successfully with `DOCKER_BUILDKIT=1`:
      - `docker build -f hugegraph-pd/Dockerfile -t hugegraph-pd:cache-test .`
      - `docker build -f hugegraph-store/Dockerfile -t hugegraph-store:cache-test .`
      - `docker build -f hugegraph-server/Dockerfile -t hugegraph-server:cache-test .`
      - `docker build -f hugegraph-server/Dockerfile-hstore -t hugegraph-server-hstore:cache-test .`
    - Rebuild images back-to-back without Java source changes and compare timings/cache reuse:
      - `hugegraph-server/Dockerfile-hstore`: `5.77s -> 2.84s` (`~50.7%` faster)
      - `hugegraph-pd/Dockerfile`: `7.79s -> 3.59s` (`~53.9%` faster)
    - Confirm build logs show cached reuse for the pom-first dependency layer, Maven cache mount, and later package/runtime layers.

## Does this PR potentially affect the following parts?

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh))
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)
- [x]  Nope

## Documentation Status

- [ ]  `Doc - TODO`
- [ ]  `Doc - Done`
- [x]  `Doc - No Need`
