### PR TITLE
fix(store): allocate graph id before batch writes

### DIFF
--- a/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/BusinessHandler.java
+++ b/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/BusinessHandler.java
@@ -152,6 +152,7 @@ public interface BusinessHandler extends DBSessionBuilder {
 
     default void doBatch(String graph, int partId, List<BatchEntry> entryList) {
         BusinessHandler.TxBuilder builder = txBuilder(graph, partId);
+        BusinessHandler.Tx transaction = builder.build();
         try {
             for (BatchEntry b : entryList) {
                 Key start = b.getStartKey();
@@ -185,12 +186,16 @@ public interface BusinessHandler extends DBSessionBuilder {
                     }
                 }
             }
-            builder.build().commit();
+            transaction.commit();
         } catch (Throwable e) {
             String msg =
                     String.format("graph data %s-%s do batch insert with error:", graph, partId);
             log.error(msg, e);
-            builder.build().rollback();
+            try {
+                transaction.rollback();
+            } catch (Throwable rollbackError) {
+                e.addSuppressed(rollbackError);
+            }
             throw e;
         }
     }

--- a/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/BusinessHandlerImpl.java
+++ b/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/BusinessHandlerImpl.java
@@ -1577,7 +1577,7 @@ public class BusinessHandlerImpl implements BusinessHandler {
         public TxBuilder put(int code, String table, byte[] key, byte[] value) throws
                                                                                HgStoreException {
             try {
-                byte[] targetKey = keyCreator.getKey(this.partId, graph, code, key);
+                byte[] targetKey = keyCreator.getKeyOrCreate(this.partId, graph, code, key);
                 this.op.put(table, targetKey, value);
             } catch (DBStoreException e) {
                 throw new HgStoreException(HgStoreException.EC_RKDB_DOPUT_FAIL, e.toString());
@@ -1642,7 +1642,7 @@ public class BusinessHandlerImpl implements BusinessHandler {
                                                                                  HgStoreException {
 
             try {
-                byte[] targetKey = keyCreator.getKey(this.partId, graph, code, key);
+                byte[] targetKey = keyCreator.getKeyOrCreate(this.partId, graph, code, key);
                 op.merge(table, targetKey, value);
             } catch (DBStoreException e) {
                 throw new HgStoreException(HgStoreException.EC_RKDB_DOMERGE_FAIL, e.toString());

--- a/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/BusinessHandlerImpl.java
+++ b/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/BusinessHandlerImpl.java
@@ -38,6 +38,9 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -121,6 +124,8 @@ public class BusinessHandlerImpl implements BusinessHandler {
 
     private static final Map<String, HugeGraphSupplier> GRAPH_SUPPLIER_CACHE =
             new ConcurrentHashMap<>();
+    private static final int GRAPH_LOCK_STRIPES = 1024;
+    private static final ReadWriteLock[] GRAPH_LOCKS = createGraphLocks();
     private static final int batchSize = 10000;
     private static Long indexDataSize = 50 * 1024L;
     private static final RocksDBFactory factory = RocksDBFactory.getInstance();
@@ -170,6 +175,20 @@ public class BusinessHandlerImpl implements BusinessHandler {
 
             }
         });
+    }
+
+    private static ReadWriteLock[] createGraphLocks() {
+        ReadWriteLock[] locks = new ReadWriteLock[GRAPH_LOCK_STRIPES];
+        for (int i = 0; i < locks.length; i++) {
+            locks[i] = new ReentrantReadWriteLock(true);
+        }
+        return locks;
+    }
+
+    private static ReadWriteLock graphLock(String graph, int partId) {
+        int hash = 31 * partId + graph.hashCode();
+        hash ^= hash >>> 16;
+        return GRAPH_LOCKS[hash & (GRAPH_LOCK_STRIPES - 1)];
     }
 
     public static HugeConfig initRocksdb(Map<String, Object> rocksdbConfig,
@@ -1014,11 +1033,17 @@ public class BusinessHandlerImpl implements BusinessHandler {
     public void truncate(String graphName, int partId) throws HgStoreException {
         // Each partition corresponds to a rocksdb instance, so the rocksdb instance name is
         // rocksdb + partId
-        try (RocksDBSession dbSession = getSession(graphName, partId)) {
-            dbSession.sessionOp().deleteRange(keyCreator.getStartKey(partId, graphName),
-                                              keyCreator.getEndKey(partId, graphName));
-            // Release map ID
-            keyCreator.delGraphId(partId, graphName);
+        Lock lifecycleLock = graphLock(graphName, partId).writeLock();
+        lifecycleLock.lock();
+        try {
+            try (RocksDBSession dbSession = getSession(graphName, partId)) {
+                dbSession.sessionOp().deleteRange(keyCreator.getStartKey(partId, graphName),
+                                                  keyCreator.getEndKey(partId, graphName));
+                // Release map ID
+                keyCreator.delGraphId(partId, graphName);
+            }
+        } finally {
+            lifecycleLock.unlock();
         }
     }
 
@@ -1287,7 +1312,7 @@ public class BusinessHandlerImpl implements BusinessHandler {
 
     @Override
     public TxBuilder txBuilder(String graph, int partId) throws HgStoreException {
-        return new TxBuilderImpl(graph, partId, getSession(graph, partId));
+        return new TxBuilderImpl(graph, partId);
     }
 
     @Override
@@ -1564,13 +1589,35 @@ public class BusinessHandlerImpl implements BusinessHandler {
         private final int partId;
         private final RocksDBSession dbSession;
         private final SessionOperator op;
+        private final Lock lifecycleLock;
+        private boolean completed;
 
-        private TxBuilderImpl(String graph, int partId, RocksDBSession dbSession) {
+        private TxBuilderImpl(String graph, int partId) {
             this.graph = graph;
             this.partId = partId;
-            this.dbSession = dbSession;
-            this.op = this.dbSession.sessionOp();
-            this.op.prepare();
+            this.lifecycleLock = graphLock(graph, partId).readLock();
+            this.lifecycleLock.lock();
+
+            RocksDBSession session = null;
+            SessionOperator operator = null;
+            try {
+                session = getSession(graph, partId);
+                operator = session.sessionOp();
+                operator.prepare();
+            } catch (RuntimeException | Error e) {
+                try {
+                    if (session != null) {
+                        session.close();
+                    }
+                } catch (Throwable closeError) {
+                    e.addSuppressed(closeError);
+                } finally {
+                    this.lifecycleLock.unlock();
+                }
+                throw e;
+            }
+            this.dbSession = session;
+            this.op = operator;
         }
 
         @Override
@@ -1655,20 +1702,36 @@ public class BusinessHandlerImpl implements BusinessHandler {
             return new Tx() {
                 @Override
                 public void commit() throws HgStoreException {
+                    if (completed) {
+                        return;
+                    }
                     op.commit();  // After an exception occurs in commit, rollback must be
                     // called, otherwise it will cause the lock not to be released.
-                    dbSession.close();
+                    completed = true;
+                    release();
                 }
 
                 @Override
                 public void rollback() throws HgStoreException {
+                    if (completed) {
+                        return;
+                    }
                     try {
                         op.rollback();
                     } finally {
-                        dbSession.close();
+                        completed = true;
+                        release();
                     }
                 }
             };
+        }
+
+        private void release() {
+            try {
+                this.dbSession.close();
+            } finally {
+                this.lifecycleLock.unlock();
+            }
         }
     }
 

--- a/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/DataManagerImpl.java
+++ b/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/DataManagerImpl.java
@@ -222,12 +222,22 @@ public class DataManagerImpl implements DataManager {
 
     @Override
     public void write(BatchPutRequest request) {
-        BusinessHandler.TxBuilder tx =
+        BusinessHandler.TxBuilder builder =
                 businessHandler.txBuilder(request.getGraphName(), request.getPartitionId());
-        for (BatchPutRequest.KV kv : request.getEntries()) {
-            tx.put(kv.getCode(), kv.getTable(), kv.getKey(), kv.getValue());
+        BusinessHandler.Tx transaction = builder.build();
+        try {
+            for (BatchPutRequest.KV kv : request.getEntries()) {
+                builder.put(kv.getCode(), kv.getTable(), kv.getKey(), kv.getValue());
+            }
+            transaction.commit();
+        } catch (Throwable e) {
+            try {
+                transaction.rollback();
+            } catch (Throwable rollbackError) {
+                e.addSuppressed(rollbackError);
+            }
+            throw e;
         }
-        tx.build().commit();
     }
 
     @Override

--- a/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/DefaultDataMover.java
+++ b/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/DefaultDataMover.java
@@ -221,12 +221,22 @@ public class DefaultDataMover implements DataMover {
 
     @Override
     public void doWriteData(BatchPutRequest request) {
-        BusinessHandler.TxBuilder tx =
+        BusinessHandler.TxBuilder builder =
                 businessHandler.txBuilder(request.getGraphName(), request.getPartitionId());
-        for (BatchPutRequest.KV kv : request.getEntries()) {
-            tx.put(kv.getCode(), kv.getTable(), kv.getKey(), kv.getValue());
+        BusinessHandler.Tx transaction = builder.build();
+        try {
+            for (BatchPutRequest.KV kv : request.getEntries()) {
+                builder.put(kv.getCode(), kv.getTable(), kv.getKey(), kv.getValue());
+            }
+            transaction.commit();
+        } catch (Throwable e) {
+            try {
+                transaction.rollback();
+            } catch (Throwable rollbackError) {
+                e.addSuppressed(rollbackError);
+            }
+            throw e;
         }
-        tx.build().commit();
     }
 
     @Override

--- a/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/meta/GraphIdManager.java
+++ b/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/meta/GraphIdManager.java
@@ -17,6 +17,8 @@
 
 package org.apache.hugegraph.store.meta;
 
+import static org.apache.hugegraph.store.constant.HugeServerTables.VERTEX_TABLE;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
@@ -128,8 +130,13 @@ public class GraphIdManager extends PartitionMetaStore {
     private boolean checkCount(long l) {
         var start = new byte[2];
         Bits.putShort(start, 0, (short) l);
-        try (var itr = sessionBuilder.getSession(partitionId).sessionOp().scan("g+v", start)) {
-            return itr == null || !itr.hasNext();
+        try (var session = sessionBuilder.getSession(partitionId)) {
+            if (!session.tableIsExist(VERTEX_TABLE)) {
+                return true;
+            }
+            try (var itr = session.sessionOp().scan(VERTEX_TABLE, start)) {
+                return itr == null || !itr.hasNext();
+            }
         }
     }
 

--- a/hugegraph-store/hg-store-test/pom.xml
+++ b/hugegraph-store/hg-store-test/pom.xml
@@ -236,6 +236,7 @@
                             </testClassesDirectory>
                             <includes>
                                 <include>**/CoreSuiteTest.java</include>
+                                <include>**/BatchGraphIsolationTest.java</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/core/BatchGraphIsolationTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/core/BatchGraphIsolationTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.store.core;
+
+import static org.apache.hugegraph.store.constant.HugeServerTables.TABLES_MAP;
+import static org.apache.hugegraph.store.constant.HugeServerTables.VERTEX_TABLE;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hugegraph.store.UnitTestBase;
+import org.apache.hugegraph.store.business.BusinessHandler;
+import org.apache.hugegraph.store.business.BusinessHandlerImpl;
+import org.apache.hugegraph.store.grpc.common.Key;
+import org.apache.hugegraph.store.grpc.common.OpType;
+import org.apache.hugegraph.store.grpc.session.BatchEntry;
+import org.apache.hugegraph.store.meta.PartitionManager;
+import org.apache.hugegraph.store.options.HgStoreEngineOptions;
+import org.apache.hugegraph.store.options.RaftRocksdbOptions;
+import org.apache.hugegraph.store.pd.FakePdServiceProvider;
+import org.apache.hugegraph.store.pd.PdProvider;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.alipay.sofa.jraft.util.StorageOptionsFactory;
+import com.google.protobuf.ByteString;
+
+public class BatchGraphIsolationTest {
+
+    private static final int PARTITION_ID = 0;
+    private static final int KEY_CODE = 0;
+    private static final byte[] SHARED_KEY =
+            "shared-key".getBytes(StandardCharsets.UTF_8);
+
+    private static Path databasePath;
+    private static BusinessHandler handler;
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        databasePath = Files.createTempDirectory("hugegraph-batch-graph-isolation-");
+
+        Map<String, Object> rocksdbConfig = new HashMap<>();
+        rocksdbConfig.put("rocksdb.write_buffer_size", "1048576");
+        StorageOptionsFactory.releaseAllOptions();
+        RaftRocksdbOptions.initRocksdbGlobalConfig(rocksdbConfig);
+        BusinessHandlerImpl.initRocksdb(rocksdbConfig, null);
+
+        HgStoreEngineOptions options = new HgStoreEngineOptions();
+        options.setDataPath(databasePath.toString());
+        options.setRaftPath(databasePath.toString());
+
+        HgStoreEngineOptions.FakePdOptions fakePdOptions =
+                new HgStoreEngineOptions.FakePdOptions();
+        fakePdOptions.setPartitionCount(1);
+        fakePdOptions.setPeersList("127.0.0.1");
+        fakePdOptions.setStoreList("127.0.0.1");
+        options.setFakePdOptions(fakePdOptions);
+
+        PdProvider pdProvider = new FakePdServiceProvider(fakePdOptions);
+        PartitionManager partitionManager = new PartitionManager(pdProvider, options) {
+
+            @Override
+            public String getDbDataPath(int partitionId, String dbName) {
+                return databasePath.resolve("data").toString();
+            }
+
+            @Override
+            public boolean hasPartition(String graphName, int partitionId) {
+                return partitionId == PARTITION_ID;
+            }
+
+            @Override
+            public List<Integer> getLeaderPartitionIds(String graph) {
+                return Collections.singletonList(PARTITION_ID);
+            }
+        };
+        handler = new BusinessHandlerImpl(partitionManager);
+        handler.createTable("setup", PARTITION_ID, VERTEX_TABLE);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        if (handler != null) {
+            handler.closeAll();
+        }
+        if (databasePath != null) {
+            UnitTestBase.deleteDir(databasePath.toFile());
+        }
+    }
+
+    @Test
+    public void testBatchPutKeepsGraphsIsolated() {
+        String graph1 = "batch-put-graph-1";
+        String graph2 = "batch-put-graph-2";
+        byte[] value1 = "graph-1-value".getBytes(StandardCharsets.UTF_8);
+        byte[] value2 = "graph-2-value".getBytes(StandardCharsets.UTF_8);
+
+        writeBatch(graph1, OpType.OP_TYPE_PUT, value1);
+        writeBatch(graph2, OpType.OP_TYPE_PUT, value2);
+
+        Assert.assertArrayEquals(value1, read(graph1));
+        Assert.assertArrayEquals(value2, read(graph2));
+
+        handler.truncate(graph2, PARTITION_ID);
+        Assert.assertArrayEquals(value1, read(graph1));
+    }
+
+    @Test
+    public void testBatchMergeKeepsGraphsIsolated() {
+        String graph1 = "batch-merge-graph-1";
+        String graph2 = "batch-merge-graph-2";
+
+        writeBatch(graph1, OpType.OP_TYPE_MERGE, longToBytes(10L));
+        writeBatch(graph2, OpType.OP_TYPE_MERGE, longToBytes(20L));
+
+        Assert.assertEquals(10L, bytesToLong(read(graph1)));
+        Assert.assertEquals(20L, bytesToLong(read(graph2)));
+    }
+
+    private static void writeBatch(String graph, OpType type, byte[] value) {
+        Key key = Key.newBuilder()
+                     .setCode(KEY_CODE)
+                     .setKey(ByteString.copyFrom(SHARED_KEY))
+                     .build();
+        BatchEntry entry = BatchEntry.newBuilder()
+                                     .setOpType(type)
+                                     .setTable(TABLES_MAP.get(VERTEX_TABLE))
+                                     .setStartKey(key)
+                                     .setValue(ByteString.copyFrom(value))
+                                     .build();
+        handler.doBatch(graph, PARTITION_ID, Collections.singletonList(entry));
+    }
+
+    private static byte[] read(String graph) {
+        return handler.doGet(graph, KEY_CODE, VERTEX_TABLE, SHARED_KEY);
+    }
+
+    private static byte[] longToBytes(long value) {
+        return ByteBuffer.allocate(Long.BYTES)
+                         .order(ByteOrder.LITTLE_ENDIAN)
+                         .putLong(value)
+                         .array();
+    }
+
+    private static long bytesToLong(byte[] value) {
+        return ByteBuffer.wrap(value)
+                         .order(ByteOrder.LITTLE_ENDIAN)
+                         .getLong();
+    }
+}

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/core/BatchGraphIsolationTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/core/BatchGraphIsolationTest.java
@@ -53,6 +53,7 @@ import com.google.protobuf.ByteString;
 public class BatchGraphIsolationTest {
 
     private static final int PARTITION_ID = 0;
+    private static final int EMPTY_PARTITION_ID = 1;
     private static final int KEY_CODE = 0;
     private static final byte[] SHARED_KEY =
             "shared-key".getBytes(StandardCharsets.UTF_8);
@@ -111,6 +112,16 @@ public class BatchGraphIsolationTest {
         if (databasePath != null) {
             UnitTestBase.deleteDir(databasePath.toFile());
         }
+    }
+
+    @Test
+    public void testGraphIdAllocationDoesNotCreateVertexTable() {
+        String graph = "graph-id-allocation";
+
+        Assert.assertFalse(handler.existsTable(graph, EMPTY_PARTITION_ID, VERTEX_TABLE));
+        ((BusinessHandlerImpl) handler).getKeyCreator()
+                                     .getGraphIdOrCreate(EMPTY_PARTITION_ID, graph);
+        Assert.assertFalse(handler.existsTable(graph, EMPTY_PARTITION_ID, VERTEX_TABLE));
     }
 
     @Test

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/core/BatchGraphIsolationTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/core/BatchGraphIsolationTest.java
@@ -30,10 +30,19 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.hugegraph.store.UnitTestBase;
 import org.apache.hugegraph.store.business.BusinessHandler;
 import org.apache.hugegraph.store.business.BusinessHandlerImpl;
+import org.apache.hugegraph.store.business.DataManagerImpl;
+import org.apache.hugegraph.store.business.DefaultDataMover;
+import org.apache.hugegraph.store.cmd.request.BatchPutRequest;
 import org.apache.hugegraph.store.grpc.common.Key;
 import org.apache.hugegraph.store.grpc.common.OpType;
 import org.apache.hugegraph.store.grpc.session.BatchEntry;
@@ -46,6 +55,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.alipay.sofa.jraft.util.StorageOptionsFactory;
 import com.google.protobuf.ByteString;
@@ -55,6 +65,7 @@ public class BatchGraphIsolationTest {
     private static final int PARTITION_ID = 0;
     private static final int EMPTY_PARTITION_ID = 1;
     private static final int KEY_CODE = 0;
+    private static final int EMPTY_PARTITION_KEY_CODE = 32768;
     private static final byte[] SHARED_KEY =
             "shared-key".getBytes(StandardCharsets.UTF_8);
 
@@ -77,7 +88,7 @@ public class BatchGraphIsolationTest {
 
         HgStoreEngineOptions.FakePdOptions fakePdOptions =
                 new HgStoreEngineOptions.FakePdOptions();
-        fakePdOptions.setPartitionCount(1);
+        fakePdOptions.setPartitionCount(2);
         fakePdOptions.setPeersList("127.0.0.1");
         fakePdOptions.setStoreList("127.0.0.1");
         options.setFakePdOptions(fakePdOptions);
@@ -92,7 +103,7 @@ public class BatchGraphIsolationTest {
 
             @Override
             public boolean hasPartition(String graphName, int partitionId) {
-                return partitionId == PARTITION_ID;
+                return partitionId == PARTITION_ID || partitionId == EMPTY_PARTITION_ID;
             }
 
             @Override
@@ -114,14 +125,99 @@ public class BatchGraphIsolationTest {
         }
     }
 
-    @Test
-    public void testGraphIdAllocationDoesNotCreateVertexTable() {
-        String graph = "graph-id-allocation";
+    @Test(timeout = 5000L)
+    public void testFirstBatchOnEmptyPartitionCompletes() {
+        String graph = "first-batch-empty-partition";
+        byte[] value = "first-value".getBytes(StandardCharsets.UTF_8);
 
         Assert.assertFalse(handler.existsTable(graph, EMPTY_PARTITION_ID, VERTEX_TABLE));
-        ((BusinessHandlerImpl) handler).getKeyCreator()
-                                     .getGraphIdOrCreate(EMPTY_PARTITION_ID, graph);
-        Assert.assertFalse(handler.existsTable(graph, EMPTY_PARTITION_ID, VERTEX_TABLE));
+        writeBatch(graph, EMPTY_PARTITION_ID, EMPTY_PARTITION_KEY_CODE,
+                   OpType.OP_TYPE_PUT, value);
+        Assert.assertArrayEquals(value, readByCode(graph, EMPTY_PARTITION_KEY_CODE));
+    }
+
+    @Test(timeout = 10000L)
+    public void testTruncateWaitsForInFlightBatch() throws Exception {
+        String graph = "in-flight-batch-graph";
+        String nextGraph = "graph-after-truncate";
+        byte[] pendingValue = "pending-value".getBytes(StandardCharsets.UTF_8);
+        byte[] nextValue = "next-value".getBytes(StandardCharsets.UTF_8);
+        BusinessHandler.TxBuilder builder = handler.txBuilder(graph, PARTITION_ID);
+        BusinessHandler.Tx transaction = builder.build();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CountDownLatch truncateStarted = new CountDownLatch(1);
+        boolean committed = false;
+
+        try {
+            put(builder, VERTEX_TABLE, pendingValue);
+            Future<?> truncate = executor.submit(() -> {
+                truncateStarted.countDown();
+                handler.truncate(graph, PARTITION_ID);
+            });
+
+            Assert.assertTrue(truncateStarted.await(1L, TimeUnit.SECONDS));
+            try {
+                truncate.get(500L, TimeUnit.MILLISECONDS);
+                Assert.fail("truncate must wait for the in-flight batch");
+            } catch (TimeoutException expected) {
+                // Expected until the transaction releases its graph ID reservation.
+            }
+
+            transaction.commit();
+            committed = true;
+            truncate.get(5L, TimeUnit.SECONDS);
+
+            writeBatch(nextGraph, OpType.OP_TYPE_PUT, nextValue);
+            Assert.assertArrayEquals(nextValue, read(nextGraph));
+        } finally {
+            if (!committed) {
+                transaction.rollback();
+            }
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testDataManagerRollsBackFailedBatch() {
+        BusinessHandler mockHandler = Mockito.mock(BusinessHandler.class);
+        BusinessHandler.TxBuilder mockBuilder = Mockito.mock(BusinessHandler.TxBuilder.class);
+        BusinessHandler.Tx mockTransaction = Mockito.mock(BusinessHandler.Tx.class);
+        BatchPutRequest request = batchPutRequest();
+        BatchPutRequest.KV entry = request.getEntries().get(0);
+        RuntimeException failure = new RuntimeException("injected put failure");
+        Mockito.when(mockHandler.txBuilder(request.getGraphName(), request.getPartitionId()))
+               .thenReturn(mockBuilder);
+        Mockito.when(mockBuilder.build()).thenReturn(mockTransaction);
+        Mockito.doThrow(failure).when(mockBuilder)
+               .put(entry.getCode(), entry.getTable(), entry.getKey(), entry.getValue());
+        DataManagerImpl dataManager = new DataManagerImpl();
+        dataManager.setBusinessHandler(mockHandler);
+
+        assertWriteFails(failure, () -> dataManager.write(request));
+
+        Mockito.verify(mockTransaction).rollback();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testDefaultDataMoverRollsBackFailedBatch() {
+        BusinessHandler mockHandler = Mockito.mock(BusinessHandler.class);
+        BusinessHandler.TxBuilder mockBuilder = Mockito.mock(BusinessHandler.TxBuilder.class);
+        BusinessHandler.Tx mockTransaction = Mockito.mock(BusinessHandler.Tx.class);
+        BatchPutRequest request = batchPutRequest();
+        BatchPutRequest.KV entry = request.getEntries().get(0);
+        RuntimeException failure = new RuntimeException("injected put failure");
+        Mockito.when(mockHandler.txBuilder(request.getGraphName(), request.getPartitionId()))
+               .thenReturn(mockBuilder);
+        Mockito.when(mockBuilder.build()).thenReturn(mockTransaction);
+        Mockito.doThrow(failure).when(mockBuilder)
+               .put(entry.getCode(), entry.getTable(), entry.getKey(), entry.getValue());
+        DefaultDataMover dataMover = new DefaultDataMover();
+        dataMover.setBusinessHandler(mockHandler);
+
+        assertWriteFails(failure, () -> dataMover.doWriteData(request));
+
+        Mockito.verify(mockTransaction).rollback();
     }
 
     @Test
@@ -154,8 +250,17 @@ public class BatchGraphIsolationTest {
     }
 
     private static void writeBatch(String graph, OpType type, byte[] value) {
+        writeBatch(graph, PARTITION_ID, type, value);
+    }
+
+    private static void writeBatch(String graph, int partitionId, OpType type, byte[] value) {
+        writeBatch(graph, partitionId, KEY_CODE, type, value);
+    }
+
+    private static void writeBatch(String graph, int partitionId, int code, OpType type,
+                                   byte[] value) {
         Key key = Key.newBuilder()
-                     .setCode(KEY_CODE)
+                     .setCode(code)
                      .setKey(ByteString.copyFrom(SHARED_KEY))
                      .build();
         BatchEntry entry = BatchEntry.newBuilder()
@@ -164,11 +269,38 @@ public class BatchGraphIsolationTest {
                                      .setStartKey(key)
                                      .setValue(ByteString.copyFrom(value))
                                      .build();
-        handler.doBatch(graph, PARTITION_ID, Collections.singletonList(entry));
+        handler.doBatch(graph, partitionId, Collections.singletonList(entry));
+    }
+
+    private static void put(BusinessHandler.TxBuilder builder, String table, byte[] value) {
+        builder.put(KEY_CODE, table, SHARED_KEY, value);
     }
 
     private static byte[] read(String graph) {
-        return handler.doGet(graph, KEY_CODE, VERTEX_TABLE, SHARED_KEY);
+        return readByCode(graph, KEY_CODE);
+    }
+
+    private static byte[] readByCode(String graph, int code) {
+        return handler.doGet(graph, code, VERTEX_TABLE, SHARED_KEY);
+    }
+
+    private static BatchPutRequest batchPutRequest() {
+        BatchPutRequest request = new BatchPutRequest();
+        request.setGraphName("failed-transfer-graph");
+        request.setPartitionId(PARTITION_ID);
+        request.getEntries()
+               .add(BatchPutRequest.KV.of(VERTEX_TABLE, KEY_CODE, SHARED_KEY,
+                                         "value".getBytes(StandardCharsets.UTF_8)));
+        return request;
+    }
+
+    private static void assertWriteFails(RuntimeException expected, Runnable writer) {
+        try {
+            writer.run();
+            Assert.fail("batch write must propagate its failure");
+        } catch (RuntimeException actual) {
+            Assert.assertSame(expected, actual);
+        }
     }
 
     private static byte[] longToBytes(long value) {

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/core/BatchGraphIsolationTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/core/BatchGraphIsolationTest.java
@@ -234,6 +234,7 @@ public class BatchGraphIsolationTest {
         Assert.assertArrayEquals(value2, read(graph2));
 
         handler.truncate(graph2, PARTITION_ID);
+        Assert.assertNull(read(graph2));
         Assert.assertArrayEquals(value1, read(graph1));
     }
 


### PR DESCRIPTION
## Overview

> [!IMPORTANT]
> HStore uses a **2-byte GraphId as the graph-isolation boundary**. Before this fix, a new graph whose first write used batch PUT or MERGE could encode data with the reserved missing GraphId `0xFFFE`. Multiple graphs could then share the same physical RocksDB key range.

<p align="center">
  <img src="https://github.com/user-attachments/assets/4261069f-0186-4a40-822f-6b10ea9d6916" alt="HStore GraphId isolation failure and fix" width="100%">
</p>

Closes #3095. This PR extracts the focused fix from https://github.com/hugegraph/hugegraph/pull/163.

## Physical key layout

```text
┌──────────────────┬──────────────────────┬──────────────────┐
│ GraphId · 2 bytes │ Logical key          │ Key code · 2 bytes │
└──────────────────┴──────────────────────┴──────────────────┘
```

The GraphId prefix is what keeps data from different graphs in separate physical ranges:

| Graph | Expected physical key | Buggy first batch write |
|---|---|---|
| Graph A | `0001 │ shared-key │ code` | `FFFE │ shared-key │ code` |
| Graph B | `0002 │ shared-key │ code` | `FFFE │ shared-key │ code` |

`65534` (`0xFFFE`) is reserved for a missing GraphId mapping. The old batch path called `getKey()`, which returned this sentinel instead of allocating an ID.

## Trigger conditions

The collision requires **all three conditions**:

| 1. New graph | 2. No mapping | 3. First write is batched |
|---|---|---|
| The graph has not written data in this partition | No GraphId exists for the graph in the target partition | The first operation enters batch PUT or MERGE |

Once multiple graphs meet these conditions in the same partition, they share the `FFFE` prefix.

## Data impact

| Operation | Result when prefixes collide |
|---|---|
| **PUT** | The same logical key can overwrite another graph's value |
| **MERGE** | Counters from different graphs can be combined |
| **TRUNCATE** | Deleting the shared physical range can remove another graph's data |

> [!NOTE]
> RocksDB accepts these keys as valid, so the corruption is silent: requests can succeed without exceptions, failed health checks, or Raft errors.

<details>
<summary><strong>Why this can remain hidden in a long-running deployment</strong></summary>

- Normal single-write paths allocate a GraphId before encoding the key.
- Long-running graphs usually already have a persisted mapping and never re-enter the first-write state.
- The failure needs multiple new graphs in the same partition; PUT/MERGE collisions are most visible when their logical keys overlap.
- Graph truncate is uncommon, and the storage layer cannot distinguish an unintended shared prefix from a valid key range.

</details>

## Fix

| Before | After |
|---|---|
| Batch PUT/MERGE used `getKey()` | Batch PUT/MERGE uses `getKeyOrCreate()` |
| Missing mapping encoded as `FFFE` | A real GraphId is allocated before key encoding |
| Truncate could race with in-flight encoded keys | A graph/partition lifecycle lock fences transaction commit or rollback from truncate |
| Batch failures could retain transaction resources | All three batch call sites roll back and release the session and lifecycle lock |

The first-allocation path also checks whether the vertex table exists before scanning it. This avoids upgrading the column-family read lock held by the prepared batch into a write path that creates the missing table.

## Regression coverage

`BatchGraphIsolationTest` exercises the real `BusinessHandler.doBatch()` and RocksDB path:

- distinct PUT values for the same logical key in two graphs;
- target-graph deletion and neighboring-graph preservation after truncate;
- isolated MERGE counters;
- first batch write on an empty partition without creating the vertex table;
- rollback of failed transfer batches;
- truncate waiting for an in-flight batch transaction.

```bash
mvn test -pl hugegraph-store/hg-store-test -am \
    -P store-core-test -Djacoco.skip=true -ntp
```

## Scope

This focused change keeps the physical-key format, public APIs, dependencies, configuration, and CI workflow unchanged. It does **not** repair already affected data or include broader GraphId lifecycle, ID-reuse, or historical-data migration work.

## PR checklist

- [x] Regression coverage added and verified
- [x] No dependency or configuration changes
- [x] No public API changes
- [x] Documentation update not required
