### PR TITLE
fix(ci): preserve PD and Store coverage aggregation

### DIFF
--- a/.github/workflows/pd-store-ci.yml
+++ b/.github/workflows/pd-store-ci.yml
@@ -100,6 +100,10 @@ jobs:
         run: |
           mvn clean package -U -Dmaven.javadoc.skip=true -Dmaven.test.skip=true -ntp --fail-at-end
 
+      - name: Check source formatting
+        run: |
+          mvn editorconfig:check -pl hugegraph-pd/hg-pd-test -am -ntp
+
       # These tests do not require starting a PD instance. Run them after the
       # clean package so their JaCoCo data survives until the final report.
       - name: Run common test
@@ -154,7 +158,8 @@ jobs:
 
       - name: Generate aggregate coverage report
         run: |
-          mvn verify -pl hugegraph-pd/hg-pd-test -am -P jacoco -DskipTests -ntp
+          mvn verify -pl hugegraph-pd/hg-pd-test -am -P jacoco \
+            -DskipTests -Deditorconfig.skip=true -ntp
 
       - name: Validate aggregate coverage report
         run: |
@@ -209,6 +214,10 @@ jobs:
         # todo remove --fail-at-end after test
         run: |
           mvn clean package -U -Dmaven.javadoc.skip=true -Dmaven.test.skip=true -ntp --fail-at-end
+
+      - name: Check source formatting
+        run: |
+          mvn editorconfig:check -pl hugegraph-store/hg-store-test -am -ntp
 
       - name: Check startup test prerequisites (Store)
         id: store-preflight
@@ -279,7 +288,8 @@ jobs:
 
       - name: Generate aggregate coverage report
         run: |
-          mvn verify -pl hugegraph-store/hg-store-test -am -P jacoco -DskipTests -ntp
+          mvn verify -pl hugegraph-store/hg-store-test -am -P jacoco \
+            -DskipTests -Deditorconfig.skip=true -ntp
 
       - name: Validate aggregate coverage report
         run: |

--- a/.github/workflows/pd-store-ci.yml
+++ b/.github/workflows/pd-store-ci.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           fetch-depth: 5
 
+      - name: Run JaCoCo report validator tests
+        run: hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
+
       - name: Use staged maven repo settings
         run: |
           cp $HOME/.m2/settings.xml /tmp/settings.xml || true
@@ -65,7 +68,7 @@ jobs:
       USE_STAGE: 'false' # Whether to include the stage repository.
       # TODO: remove outdated env
       TRAVIS_DIR: hugegraph-server/hugegraph-dist/src/assembly/travis
-      REPORT_DIR: target/site/jacoco
+      REPORT_FILE: hugegraph-pd/hg-pd-test/target/site/jacoco/jacoco.xml
 
     steps:
       - name: Install JDK 11
@@ -92,20 +95,22 @@ jobs:
           cp $HOME/.m2/settings.xml /tmp/settings.xml
           mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
 
-      - name: Run common test
-        run: |
-          mvn test -pl hugegraph-pd/hg-pd-test -am -P pd-common-test
-
-      - name: Run core test
-        run: |
-          mvn test -pl hugegraph-pd/hg-pd-test -am -P pd-core-test
-
-      # The above tests do not require starting a PD instance.
-
       - name: Package
         # todo remove --fail-at-end after test
         run: |
           mvn clean package -U -Dmaven.javadoc.skip=true -Dmaven.test.skip=true -ntp --fail-at-end
+
+      # These tests do not require starting a PD instance. Run them after the
+      # clean package so their JaCoCo data survives until the final report.
+      - name: Run common test
+        run: |
+          mvn test -pl hugegraph-pd/hg-pd-test -am \
+            -P pd-common-test -Djacoco.sessionId=pd-common-test
+
+      - name: Run core test
+        run: |
+          mvn test -pl hugegraph-pd/hg-pd-test -am \
+            -P pd-core-test -Djacoco.sessionId=pd-core-test
 
       - name: Check startup test prerequisites (PD)
         id: pd-preflight
@@ -139,16 +144,32 @@ jobs:
 
       - name: Run client test
         run: |
-          mvn test -pl hugegraph-pd/hg-pd-test -am -P pd-client-test
+          mvn test -pl hugegraph-pd/hg-pd-test -am \
+            -P pd-client-test -Djacoco.sessionId=pd-client-test
 
       - name: Run rest test
         run: |
-          mvn test -pl hugegraph-pd/hg-pd-test -am -P pd-rest-test
+          mvn test -pl hugegraph-pd/hg-pd-test -am \
+            -P pd-rest-test -Djacoco.sessionId=pd-rest-test
+
+      - name: Generate aggregate coverage report
+        run: |
+          mvn verify -pl hugegraph-pd/hg-pd-test -am -P jacoco -DskipTests -ntp
+
+      - name: Validate aggregate coverage report
+        run: |
+          $TRAVIS_DIR/check-jacoco-report.sh \
+            --require-session pd-common-test \
+            --require-session pd-core-test \
+            --require-session pd-client-test \
+            --require-session pd-rest-test \
+            "$REPORT_FILE" \
+            hg-pd-grpc hg-pd-common hg-pd-client hg-pd-core hg-pd-service hg-pd-dist
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.0.0
         with:
-          file: ${{ env.REPORT_DIR }}/*.xml
+          files: ${{ env.REPORT_FILE }}
 
   store:
     needs: struct
@@ -157,7 +178,7 @@ jobs:
       USE_STAGE: 'false' # Whether to include the stage repository.
       # TODO: remove outdated env
       TRAVIS_DIR: hugegraph-server/hugegraph-dist/src/assembly/travis
-      REPORT_DIR: target/site/jacoco
+      REPORT_FILE: hugegraph-store/hg-store-test/target/site/jacoco/jacoco.xml
 
     steps:
       - name: Install JDK 11
@@ -228,32 +249,55 @@ jobs:
 
       - name: Run common test
         run: |
-          mvn test -pl hugegraph-store/hg-store-test -am -P store-common-test
+          mvn test -pl hugegraph-store/hg-store-test -am \
+            -P store-common-test -Djacoco.sessionId=store-common-test
 
       - name: Run client test
         run: |
-          mvn test -pl hugegraph-store/hg-store-test -am -P store-client-test
+          mvn test -pl hugegraph-store/hg-store-test -am \
+            -P store-client-test -Djacoco.sessionId=store-client-test
 
       - name: Run core test
         run: |
-          mvn test -pl hugegraph-store/hg-store-test -am -P store-core-test
+          mvn test -pl hugegraph-store/hg-store-test -am \
+            -P store-core-test -Djacoco.sessionId=store-core-test
 
       - name: Run rocksdb test
         run: |
-          mvn test -pl hugegraph-store/hg-store-test -am -P store-rocksdb-test
+          mvn test -pl hugegraph-store/hg-store-test -am \
+            -P store-rocksdb-test -Djacoco.sessionId=store-rocksdb-test
 
       - name: Run server test
         run: |
-          mvn test -pl hugegraph-store/hg-store-test -am -P store-server-test
+          mvn test -pl hugegraph-store/hg-store-test -am \
+            -P store-server-test -Djacoco.sessionId=store-server-test
 
       - name: Run raft-core test
         run: |
-          mvn test -pl hugegraph-store/hg-store-test -am -P store-raftcore-test
+          mvn test -pl hugegraph-store/hg-store-test -am \
+            -P store-raftcore-test -Djacoco.sessionId=store-raftcore-test
+
+      - name: Generate aggregate coverage report
+        run: |
+          mvn verify -pl hugegraph-store/hg-store-test -am -P jacoco -DskipTests -ntp
+
+      - name: Validate aggregate coverage report
+        run: |
+          $TRAVIS_DIR/check-jacoco-report.sh \
+            --require-session store-common-test \
+            --require-session store-client-test \
+            --require-session store-core-test \
+            --require-session store-rocksdb-test \
+            --require-session store-server-test \
+            --require-session store-raftcore-test \
+            "$REPORT_FILE" \
+            hg-store-grpc hg-store-common hg-store-client hg-store-rocksdb \
+            hg-store-core hg-store-node
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.0.0
         with:
-          file: ${{ env.REPORT_DIR }}/*.xml
+          files: ${{ env.REPORT_FILE }}
 
   hstore:
     needs: struct

--- a/.github/workflows/pd-store-ci.yml
+++ b/.github/workflows/pd-store-ci.yml
@@ -276,20 +276,10 @@ jobs:
           mvn test -pl hugegraph-store/hg-store-test -am \
             -P store-client-test -Djacoco.sessionId=store-client-test
 
-      - name: Run core test
-        run: |
-          mvn test -pl hugegraph-store/hg-store-test -am \
-            -P store-core-test -Djacoco.sessionId=store-core-test
-
       - name: Run rocksdb test
         run: |
           mvn test -pl hugegraph-store/hg-store-test -am \
             -P store-rocksdb-test -Djacoco.sessionId=store-rocksdb-test
-
-      - name: Run server test
-        run: |
-          mvn test -pl hugegraph-store/hg-store-test -am \
-            -P store-server-test -Djacoco.sessionId=store-server-test
 
       - name: Run raft-core test
         run: |
@@ -303,29 +293,21 @@ jobs:
 
       - name: Validate aggregate coverage report
         run: |
-          # CoreSuiteTest and ServerSuiteTest are existing placeholders with zero tests.
           $TRAVIS_DIR/check-jacoco-report.sh \
             --require-test-report \
             "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.common.CommonSuiteTest.xml" \
             --require-test-report \
             "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.client.ClientSuiteTest.xml" \
-            --require-suite-report \
-            "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.core.CoreSuiteTest.xml" \
             --require-test-report \
             "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.rocksdb.RocksDbSuiteTest.xml" \
-            --require-suite-report \
-            "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.service.ServerSuiteTest.xml" \
             --require-test-report \
             "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.raftcore.RaftSuiteTest.xml" \
             --require-session store-common-test \
             --require-session store-client-test \
-            --require-session store-core-test \
             --require-session store-rocksdb-test \
-            --require-session store-server-test \
             --require-session store-raftcore-test \
             "$REPORT_FILE" \
-            hg-store-grpc hg-store-common hg-store-client hg-store-rocksdb \
-            hg-store-core hg-store-node
+            hg-store-grpc hg-store-common hg-store-client hg-store-rocksdb
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.0.0

--- a/.github/workflows/pd-store-ci.yml
+++ b/.github/workflows/pd-store-ci.yml
@@ -69,6 +69,7 @@ jobs:
       # TODO: remove outdated env
       TRAVIS_DIR: hugegraph-server/hugegraph-dist/src/assembly/travis
       REPORT_FILE: hugegraph-pd/hg-pd-test/target/site/jacoco/jacoco.xml
+      TEST_REPORT_DIR: hugegraph-pd/hg-pd-test/target/surefire-reports
 
     steps:
       - name: Install JDK 11
@@ -164,6 +165,14 @@ jobs:
       - name: Validate aggregate coverage report
         run: |
           $TRAVIS_DIR/check-jacoco-report.sh \
+            --require-test-report \
+            "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.pd.common.CommonSuiteTest.xml" \
+            --require-test-report \
+            "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.pd.core.PDCoreSuiteTest.xml" \
+            --require-test-report \
+            "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.pd.client.PDClientSuiteTest.xml" \
+            --require-test-report \
+            "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.pd.rest.PDRestSuiteTest.xml" \
             --require-session pd-common-test \
             --require-session pd-core-test \
             --require-session pd-client-test \
@@ -184,6 +193,7 @@ jobs:
       # TODO: remove outdated env
       TRAVIS_DIR: hugegraph-server/hugegraph-dist/src/assembly/travis
       REPORT_FILE: hugegraph-store/hg-store-test/target/site/jacoco/jacoco.xml
+      TEST_REPORT_DIR: hugegraph-store/hg-store-test/target/surefire-reports
 
     steps:
       - name: Install JDK 11
@@ -266,20 +276,10 @@ jobs:
           mvn test -pl hugegraph-store/hg-store-test -am \
             -P store-client-test -Djacoco.sessionId=store-client-test
 
-      - name: Run core test
-        run: |
-          mvn test -pl hugegraph-store/hg-store-test -am \
-            -P store-core-test -Djacoco.sessionId=store-core-test
-
       - name: Run rocksdb test
         run: |
           mvn test -pl hugegraph-store/hg-store-test -am \
             -P store-rocksdb-test -Djacoco.sessionId=store-rocksdb-test
-
-      - name: Run server test
-        run: |
-          mvn test -pl hugegraph-store/hg-store-test -am \
-            -P store-server-test -Djacoco.sessionId=store-server-test
 
       - name: Run raft-core test
         run: |
@@ -294,11 +294,17 @@ jobs:
       - name: Validate aggregate coverage report
         run: |
           $TRAVIS_DIR/check-jacoco-report.sh \
+            --require-test-report \
+            "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.common.CommonSuiteTest.xml" \
+            --require-test-report \
+            "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.client.ClientSuiteTest.xml" \
+            --require-test-report \
+            "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.rocksdb.RocksDbSuiteTest.xml" \
+            --require-test-report \
+            "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.raftcore.RaftSuiteTest.xml" \
             --require-session store-common-test \
             --require-session store-client-test \
-            --require-session store-core-test \
             --require-session store-rocksdb-test \
-            --require-session store-server-test \
             --require-session store-raftcore-test \
             "$REPORT_FILE" \
             hg-store-grpc hg-store-common hg-store-client hg-store-rocksdb \

--- a/.github/workflows/pd-store-ci.yml
+++ b/.github/workflows/pd-store-ci.yml
@@ -173,6 +173,9 @@ jobs:
             "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.pd.client.PDClientSuiteTest.xml" \
             --require-test-report \
             "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.pd.rest.PDRestSuiteTest.xml" \
+            --require-covered-group hg-pd-common \
+            --require-covered-group hg-pd-client \
+            --require-covered-group hg-pd-core \
             --require-session pd-common-test \
             --require-session pd-core-test \
             --require-session pd-client-test \
@@ -302,6 +305,9 @@ jobs:
             "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.rocksdb.RocksDbSuiteTest.xml" \
             --require-test-report \
             "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.raftcore.RaftSuiteTest.xml" \
+            --require-covered-group hg-store-common \
+            --require-covered-group hg-store-client \
+            --require-covered-group hg-store-rocksdb \
             --require-session store-common-test \
             --require-session store-client-test \
             --require-session store-rocksdb-test \

--- a/.github/workflows/pd-store-ci.yml
+++ b/.github/workflows/pd-store-ci.yml
@@ -276,10 +276,20 @@ jobs:
           mvn test -pl hugegraph-store/hg-store-test -am \
             -P store-client-test -Djacoco.sessionId=store-client-test
 
+      - name: Run core test
+        run: |
+          mvn test -pl hugegraph-store/hg-store-test -am \
+            -P store-core-test -Djacoco.sessionId=store-core-test
+
       - name: Run rocksdb test
         run: |
           mvn test -pl hugegraph-store/hg-store-test -am \
             -P store-rocksdb-test -Djacoco.sessionId=store-rocksdb-test
+
+      - name: Run server test
+        run: |
+          mvn test -pl hugegraph-store/hg-store-test -am \
+            -P store-server-test -Djacoco.sessionId=store-server-test
 
       - name: Run raft-core test
         run: |
@@ -293,18 +303,25 @@ jobs:
 
       - name: Validate aggregate coverage report
         run: |
+          # CoreSuiteTest and ServerSuiteTest are existing placeholders with zero tests.
           $TRAVIS_DIR/check-jacoco-report.sh \
             --require-test-report \
             "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.common.CommonSuiteTest.xml" \
             --require-test-report \
             "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.client.ClientSuiteTest.xml" \
+            --require-suite-report \
+            "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.core.CoreSuiteTest.xml" \
             --require-test-report \
             "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.rocksdb.RocksDbSuiteTest.xml" \
+            --require-suite-report \
+            "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.service.ServerSuiteTest.xml" \
             --require-test-report \
             "$TEST_REPORT_DIR/TEST-org.apache.hugegraph.store.raftcore.RaftSuiteTest.xml" \
             --require-session store-common-test \
             --require-session store-client-test \
+            --require-session store-core-test \
             --require-session store-rocksdb-test \
+            --require-session store-server-test \
             --require-session store-raftcore-test \
             "$REPORT_FILE" \
             hg-store-grpc hg-store-common hg-store-client hg-store-rocksdb \

--- a/hugegraph-pd/hg-pd-test/pom.xml
+++ b/hugegraph-pd/hg-pd-test/pom.xml
@@ -46,18 +46,19 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.4</version>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/grpc/**.*</exclude>
-                                <exclude>**/config/**.*</exclude>
-                            </excludes>
-                        </configuration>
+                        <version>0.8.8</version>
                         <executions>
                             <execution>
+                                <id>coverage-report</id>
+                                <phase>verify</phase>
                                 <goals>
-                                    <goal>prepare-agent</goal>
+                                    <goal>report-aggregate</goal>
                                 </goals>
+                                <configuration>
+                                    <outputDirectory>
+                                        ${project.basedir}/target/site/jacoco
+                                    </outputDirectory>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -258,25 +259,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
-                <executions>
-                    <execution>
-                        <id>pre-test</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>post-test</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report-aggregate</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${basedir}/target/site/jacoco</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>org/apache/hugegraph/pd/rest/*.class</exclude>

--- a/hugegraph-pd/pom.xml
+++ b/hugegraph-pd/pom.xml
@@ -74,8 +74,9 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
+                    <append>true</append>
                     <excludes>
                         <exclude>**/grpc/**.*</exclude>
                         <exclude>**/config/**.*</exclude>

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/check-jacoco-report.sh
@@ -19,9 +19,33 @@
 set -uo pipefail
 
 REQUIRED_SESSIONS=()
-while [[ "${1:-}" == "--require-session" ]]; do
-    REQUIRED_SESSIONS+=("${2:-}")
-    shift 2 || true
+REQUIRED_TEST_REPORTS=()
+while (( $# > 0 )); do
+    case "${1}" in
+        --require-session)
+            if (( $# < 2 )) || [[ -z "${2:-}" || "${2}" == --* ]]; then
+                echo "ERROR: --require-session requires a non-empty value" >&2
+                exit 1
+            fi
+            REQUIRED_SESSIONS+=("${2}")
+            shift 2
+            ;;
+        --require-test-report)
+            if (( $# < 2 )) || [[ -z "${2:-}" || "${2}" == --* ]]; then
+                echo "ERROR: --require-test-report requires a non-empty value" >&2
+                exit 1
+            fi
+            REQUIRED_TEST_REPORTS+=("${2}")
+            shift 2
+            ;;
+        --*)
+            echo "ERROR: unknown option: ${1}" >&2
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
 done
 
 if (( ${#REQUIRED_SESSIONS[@]} == 0 )); then
@@ -29,13 +53,48 @@ if (( ${#REQUIRED_SESSIONS[@]} == 0 )); then
     exit 1
 fi
 
+if (( ${#REQUIRED_TEST_REPORTS[@]} == 0 )); then
+    echo "ERROR: at least one --require-test-report is required" >&2
+    exit 1
+fi
+
 REPORT_FILE="${1:-}"
-shift || true
+if (( $# > 0 )); then
+    shift
+fi
 
 if [[ -z "${REPORT_FILE}" || ! -s "${REPORT_FILE}" ]]; then
     echo "ERROR: JaCoCo report not found or empty: ${REPORT_FILE:-<unset>}" >&2
     exit 1
 fi
+
+if (( $# == 0 )); then
+    echo "ERROR: at least one expected module is required" >&2
+    exit 1
+fi
+
+for test_report in "${REQUIRED_TEST_REPORTS[@]}"; do
+    if [[ ! -s "${test_report}" ]]; then
+        echo "ERROR: Surefire report not found or empty: ${test_report}" >&2
+        exit 1
+    fi
+
+    if ! test_count=$(python3 - "${test_report}" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+root = ET.parse(sys.argv[1]).getroot()
+print(int(root.attrib.get("tests", "0")))
+PY
+    ); then
+        echo "ERROR: unable to parse Surefire report: ${test_report}" >&2
+        exit 1
+    fi
+    if (( test_count <= 0 )); then
+        echo "ERROR: Surefire report has no tests: ${test_report}" >&2
+        exit 1
+    fi
+done
 
 if ! grep -Eq '<counter type="INSTRUCTION" missed="[0-9]+" covered="[1-9][0-9]*"' \
      "${REPORT_FILE}"; then

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/check-jacoco-report.sh
@@ -90,8 +90,8 @@ validate_test_report() {
         return 1
     fi
 
-    local test_count
-    if ! test_count=$(python3 - "${test_report}" <<'PY'
+    local test_counts
+    if ! test_counts=$(python3 - "${test_report}" <<'PY'
 import sys
 import xml.etree.ElementTree as ET
 
@@ -99,16 +99,26 @@ root = ET.parse(sys.argv[1]).getroot()
 if root.tag.rsplit("}", 1)[-1] != "testsuite" or "tests" not in root.attrib:
     raise ValueError("not a Surefire testsuite report")
 test_count = int(root.attrib["tests"])
+skipped_count = int(root.attrib.get("skipped", "0"))
 if test_count < 0:
     raise ValueError("negative Surefire test count")
-print(test_count)
+if skipped_count < 0 or skipped_count > test_count:
+    raise ValueError("invalid Surefire skipped count")
+print(test_count, test_count - skipped_count)
 PY
     ); then
         echo "ERROR: unable to parse Surefire report: ${test_report}" >&2
         return 1
     fi
+    local test_count
+    local executed_count
+    read -r test_count executed_count <<< "${test_counts}"
     if (( test_count <= 0 )); then
         echo "ERROR: Surefire report has no tests: ${test_report}" >&2
+        return 1
+    fi
+    if (( executed_count <= 0 )); then
+        echo "ERROR: Surefire report has no executed tests: ${test_report}" >&2
         return 1
     fi
 }

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/check-jacoco-report.sh
@@ -20,6 +20,7 @@ set -uo pipefail
 
 REQUIRED_SESSIONS=()
 REQUIRED_TEST_REPORTS=()
+REQUIRED_COVERED_GROUPS=()
 while (( $# > 0 )); do
     case "${1}" in
         --require-session)
@@ -36,6 +37,14 @@ while (( $# > 0 )); do
                 exit 1
             fi
             REQUIRED_TEST_REPORTS+=("${2}")
+            shift 2
+            ;;
+        --require-covered-group)
+            if (( $# < 2 )) || [[ -z "${2:-}" || "${2}" == --* ]]; then
+                echo "ERROR: --require-covered-group requires a non-empty value" >&2
+                exit 1
+            fi
+            REQUIRED_COVERED_GROUPS+=("${2}")
             shift 2
             ;;
         --*)
@@ -108,14 +117,18 @@ for test_report in "${REQUIRED_TEST_REPORTS[@]}"; do
     validate_test_report "${test_report}" || exit 1
 done
 
-python3 - "${REPORT_FILE}" "${REQUIRED_SESSIONS[@]}" -- "$@" <<'PY' || exit 1
+python3 - "${REPORT_FILE}" "${REQUIRED_SESSIONS[@]}" -- \
+    ${REQUIRED_COVERED_GROUPS[@]+"${REQUIRED_COVERED_GROUPS[@]}"} \
+    -- "$@" <<'PY' || exit 1
 import sys
 import xml.etree.ElementTree as ET
 
 report_file = sys.argv[1]
-separator = sys.argv.index("--", 2)
-required_sessions = sys.argv[2:separator]
-required_modules = sys.argv[separator + 1:]
+session_separator = sys.argv.index("--", 2)
+group_separator = sys.argv.index("--", session_separator + 1)
+required_sessions = sys.argv[2:session_separator]
+required_covered_groups = sys.argv[session_separator + 1:group_separator]
+required_modules = sys.argv[group_separator + 1:]
 
 
 def fail(message):
@@ -157,13 +170,31 @@ for session in required_sessions:
     if session not in session_ids:
         fail(f"missing JaCoCo session '{session}' in {report_file}")
 
-group_names = {
-    element.attrib.get("name") for element in children
+groups_by_name = {
+    element.attrib.get("name"): element for element in children
     if local_name(element.tag) == "group"
 }
 for module in required_modules:
-    if module not in group_names:
+    if module not in groups_by_name:
         fail(f"missing JaCoCo group '{module}' in {report_file}")
+
+for group_name in required_covered_groups:
+    group = groups_by_name.get(group_name)
+    if group is None:
+        fail(f"missing JaCoCo group '{group_name}' in {report_file}")
+    counters = [
+        element for element in list(group)
+        if local_name(element.tag) == "counter" and
+        element.attrib.get("type") == "INSTRUCTION"
+    ]
+    try:
+        has_coverage = any(int(counter.attrib.get("covered", "0")) > 0
+                           for counter in counters)
+    except ValueError as error:
+        fail(f"unable to parse JaCoCo report: {report_file}: {error}")
+    if not has_coverage:
+        fail(f"JaCoCo group '{group_name}' has no covered instructions: "
+             f"{report_file}")
 PY
 
 echo "JaCoCo report ${REPORT_FILE} contains all expected modules"

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/check-jacoco-report.sh
@@ -20,7 +20,6 @@ set -uo pipefail
 
 REQUIRED_SESSIONS=()
 REQUIRED_TEST_REPORTS=()
-REQUIRED_SUITE_REPORTS=()
 while (( $# > 0 )); do
     case "${1}" in
         --require-session)
@@ -37,14 +36,6 @@ while (( $# > 0 )); do
                 exit 1
             fi
             REQUIRED_TEST_REPORTS+=("${2}")
-            shift 2
-            ;;
-        --require-suite-report)
-            if (( $# < 2 )) || [[ -z "${2:-}" || "${2}" == --* ]]; then
-                echo "ERROR: --require-suite-report requires a non-empty value" >&2
-                exit 1
-            fi
-            REQUIRED_SUITE_REPORTS+=("${2}")
             shift 2
             ;;
         --*)
@@ -84,7 +75,6 @@ fi
 
 validate_test_report() {
     local test_report="${1}"
-    local require_tests="${2}"
 
     if [[ ! -s "${test_report}" ]]; then
         echo "ERROR: Surefire report not found or empty: ${test_report}" >&2
@@ -108,38 +98,72 @@ PY
         echo "ERROR: unable to parse Surefire report: ${test_report}" >&2
         return 1
     fi
-    if [[ "${require_tests}" == "true" ]] && (( test_count <= 0 )); then
+    if (( test_count <= 0 )); then
         echo "ERROR: Surefire report has no tests: ${test_report}" >&2
         return 1
     fi
 }
 
-for suite_report in "${REQUIRED_SUITE_REPORTS[@]}"; do
-    validate_test_report "${suite_report}" false || exit 1
-done
-
 for test_report in "${REQUIRED_TEST_REPORTS[@]}"; do
-    validate_test_report "${test_report}" true || exit 1
+    validate_test_report "${test_report}" || exit 1
 done
 
-if ! grep -Eq '<counter type="INSTRUCTION" missed="[0-9]+" covered="[1-9][0-9]*"' \
-     "${REPORT_FILE}"; then
-    echo "ERROR: JaCoCo report has no covered instructions: ${REPORT_FILE}" >&2
-    exit 1
-fi
+python3 - "${REPORT_FILE}" "${REQUIRED_SESSIONS[@]}" -- "$@" <<'PY' || exit 1
+import sys
+import xml.etree.ElementTree as ET
 
-for session in "${REQUIRED_SESSIONS[@]}"; do
-    if ! grep -Fq "<sessioninfo id=\"${session}\" " "${REPORT_FILE}"; then
-        echo "ERROR: missing JaCoCo session '${session}' in ${REPORT_FILE}" >&2
-        exit 1
-    fi
-done
+report_file = sys.argv[1]
+separator = sys.argv.index("--", 2)
+required_sessions = sys.argv[2:separator]
+required_modules = sys.argv[separator + 1:]
 
-for module in "$@"; do
-    if ! grep -Fq "<group name=\"${module}\"" "${REPORT_FILE}"; then
-        echo "ERROR: missing JaCoCo group '${module}' in ${REPORT_FILE}" >&2
-        exit 1
-    fi
-done
+
+def fail(message):
+    print(f"ERROR: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def local_name(tag):
+    return tag.rsplit("}", 1)[-1]
+
+
+try:
+    root = ET.parse(report_file).getroot()
+except (OSError, ET.ParseError) as error:
+    fail(f"unable to parse JaCoCo report: {report_file}: {error}")
+
+if local_name(root.tag) != "report":
+    fail(f"unable to parse JaCoCo report: {report_file}: expected report root")
+
+children = list(root)
+instruction_counters = [
+    element for element in children
+    if local_name(element.tag) == "counter" and
+    element.attrib.get("type") == "INSTRUCTION"
+]
+try:
+    has_coverage = any(int(counter.attrib.get("covered", "0")) > 0
+                       for counter in instruction_counters)
+except ValueError as error:
+    fail(f"unable to parse JaCoCo report: {report_file}: {error}")
+if not has_coverage:
+    fail(f"JaCoCo report has no covered instructions: {report_file}")
+
+session_ids = {
+    element.attrib.get("id") for element in children
+    if local_name(element.tag) == "sessioninfo"
+}
+for session in required_sessions:
+    if session not in session_ids:
+        fail(f"missing JaCoCo session '{session}' in {report_file}")
+
+group_names = {
+    element.attrib.get("name") for element in children
+    if local_name(element.tag) == "group"
+}
+for module in required_modules:
+    if module not in group_names:
+        fail(f"missing JaCoCo group '{module}' in {report_file}")
+PY
 
 echo "JaCoCo report ${REPORT_FILE} contains all expected modules"

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/check-jacoco-report.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -uo pipefail
+
+REQUIRED_SESSIONS=()
+while [[ "${1:-}" == "--require-session" ]]; do
+    REQUIRED_SESSIONS+=("${2:-}")
+    shift 2 || true
+done
+
+if (( ${#REQUIRED_SESSIONS[@]} == 0 )); then
+    echo "ERROR: at least one --require-session is required" >&2
+    exit 1
+fi
+
+REPORT_FILE="${1:-}"
+shift || true
+
+if [[ -z "${REPORT_FILE}" || ! -s "${REPORT_FILE}" ]]; then
+    echo "ERROR: JaCoCo report not found or empty: ${REPORT_FILE:-<unset>}" >&2
+    exit 1
+fi
+
+if ! grep -Eq '<counter type="INSTRUCTION" missed="[0-9]+" covered="[1-9][0-9]*"' \
+     "${REPORT_FILE}"; then
+    echo "ERROR: JaCoCo report has no covered instructions: ${REPORT_FILE}" >&2
+    exit 1
+fi
+
+for session in "${REQUIRED_SESSIONS[@]}"; do
+    if ! grep -Fq "<sessioninfo id=\"${session}\" " "${REPORT_FILE}"; then
+        echo "ERROR: missing JaCoCo session '${session}' in ${REPORT_FILE}" >&2
+        exit 1
+    fi
+done
+
+for module in "$@"; do
+    if ! grep -Fq "<group name=\"${module}\"" "${REPORT_FILE}"; then
+        echo "ERROR: missing JaCoCo group '${module}' in ${REPORT_FILE}" >&2
+        exit 1
+    fi
+done
+
+echo "JaCoCo report ${REPORT_FILE} contains all expected modules"

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/check-jacoco-report.sh
@@ -20,6 +20,7 @@ set -uo pipefail
 
 REQUIRED_SESSIONS=()
 REQUIRED_TEST_REPORTS=()
+REQUIRED_SUITE_REPORTS=()
 while (( $# > 0 )); do
     case "${1}" in
         --require-session)
@@ -36,6 +37,14 @@ while (( $# > 0 )); do
                 exit 1
             fi
             REQUIRED_TEST_REPORTS+=("${2}")
+            shift 2
+            ;;
+        --require-suite-report)
+            if (( $# < 2 )) || [[ -z "${2:-}" || "${2}" == --* ]]; then
+                echo "ERROR: --require-suite-report requires a non-empty value" >&2
+                exit 1
+            fi
+            REQUIRED_SUITE_REPORTS+=("${2}")
             shift 2
             ;;
         --*)
@@ -73,27 +82,44 @@ if (( $# == 0 )); then
     exit 1
 fi
 
-for test_report in "${REQUIRED_TEST_REPORTS[@]}"; do
+validate_test_report() {
+    local test_report="${1}"
+    local require_tests="${2}"
+
     if [[ ! -s "${test_report}" ]]; then
         echo "ERROR: Surefire report not found or empty: ${test_report}" >&2
-        exit 1
+        return 1
     fi
 
+    local test_count
     if ! test_count=$(python3 - "${test_report}" <<'PY'
 import sys
 import xml.etree.ElementTree as ET
 
 root = ET.parse(sys.argv[1]).getroot()
-print(int(root.attrib.get("tests", "0")))
+if root.tag.rsplit("}", 1)[-1] != "testsuite" or "tests" not in root.attrib:
+    raise ValueError("not a Surefire testsuite report")
+test_count = int(root.attrib["tests"])
+if test_count < 0:
+    raise ValueError("negative Surefire test count")
+print(test_count)
 PY
     ); then
         echo "ERROR: unable to parse Surefire report: ${test_report}" >&2
-        exit 1
+        return 1
     fi
-    if (( test_count <= 0 )); then
+    if [[ "${require_tests}" == "true" ]] && (( test_count <= 0 )); then
         echo "ERROR: Surefire report has no tests: ${test_report}" >&2
-        exit 1
+        return 1
     fi
+}
+
+for suite_report in "${REQUIRED_SUITE_REPORTS[@]}"; do
+    validate_test_report "${suite_report}" false || exit 1
+done
+
+for test_report in "${REQUIRED_TEST_REPORTS[@]}"; do
+    validate_test_report "${test_report}" true || exit 1
 done
 
 if ! grep -Eq '<counter type="INSTRUCTION" missed="[0-9]+" covered="[1-9][0-9]*"' \

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
@@ -73,6 +73,11 @@ cat > "${TMP_DIR}/zero-tests.xml" <<'EOF'
 <testsuite name="EmptySuiteTest" tests="0" failures="0" errors="0" skipped="0"/>
 EOF
 
+cat > "${TMP_DIR}/not-surefire.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<report tests="0"/>
+EOF
+
 echo "JaCoCo report validator tests"
 
 run_case_with_timeout --require-session
@@ -87,6 +92,14 @@ assert_output "--require-session requires a non-empty value"
 run_case --require-test-report
 assert_failure "missing test report value"
 assert_output "--require-test-report requires a non-empty value"
+
+run_case --require-suite-report
+assert_failure "missing suite report value"
+assert_output "--require-suite-report requires a non-empty value"
+
+run_case --require-suite-report ""
+assert_failure "empty suite report value"
+assert_output "--require-suite-report requires a non-empty value"
 
 run_report_case --require-session suite-a "${TMP_DIR}/missing.xml" hg-pd-client
 assert_failure "missing report"
@@ -129,6 +142,26 @@ run_case --require-test-report "${TMP_DIR}/zero-tests.xml" \
          "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
 assert_failure "required test report without tests"
 assert_output "Surefire report has no tests"
+
+run_case --require-suite-report "${TMP_DIR}/zero-tests.xml" \
+         --require-test-report "${TMP_DIR}/tests.xml" \
+         --require-session suite-a --require-session suite-b \
+         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
+assert_success "required zero-test suite report"
+
+run_case --require-suite-report "${TMP_DIR}/missing-suite.xml" \
+         --require-test-report "${TMP_DIR}/tests.xml" \
+         --require-session suite-a --require-session suite-b \
+         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
+assert_failure "missing required suite report"
+assert_output "Surefire report not found or empty"
+
+run_case --require-suite-report "${TMP_DIR}/not-surefire.xml" \
+         --require-test-report "${TMP_DIR}/tests.xml" \
+         --require-session suite-a --require-session suite-b \
+         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
+assert_failure "required suite report with invalid root"
+assert_output "unable to parse Surefire report"
 
 run_report_case --require-session suite-a --require-session suite-b \
                 "${TMP_DIR}/valid.xml"
@@ -221,6 +254,15 @@ assert profile_dependencies is not None
 assert any(child_text(dep, "artifactId") == "hg-store-rocksdb"
            for dep in profile_dependencies.findall(NS + "dependency"))
 
+core_suite = (ROOT / "hugegraph-store/hg-store-test/src/main/java/org/apache/"
+              "hugegraph/store/core/CoreSuiteTest.java").read_text()
+core_suite_code = "\n".join(
+    line for line in core_suite.splitlines()
+    if not line.lstrip().startswith("//")
+)
+assert "@RunWith(Suite.class)" in core_suite_code
+assert re.search(r"@Suite[.]SuiteClasses[(][{]\s*[}][)]", core_suite_code)
+
 workflow = (ROOT / ".github/workflows/pd-store-ci.yml").read_text()
 pd_job = workflow.split("\n  pd:\n", 1)[1].split("\n  store:\n", 1)[0]
 store_job = workflow.split("\n  store:\n", 1)[1].split("\n  hstore:\n", 1)[0]
@@ -236,9 +278,12 @@ def validation_command(job):
         "- name: Upload coverage", 1)[0]
 
 
-def required_test_reports(job):
-    return set(re.findall(r"TEST-[A-Za-z0-9_.]+SuiteTest[.]xml",
-                          validation_command(job)))
+def reports_for_option(job, option):
+    pattern = re.escape(option) + (
+        r'\s+\\?\s*"\$TEST_REPORT_DIR/'
+        r'(TEST-[A-Za-z0-9_.]+SuiteTest[.]xml)"'
+    )
+    return set(re.findall(pattern, validation_command(job)))
 
 
 def required_modules(job):
@@ -270,12 +315,13 @@ assert "mvn verify -pl hugegraph-pd/hg-pd-test -am -P jacoco \\ " \
 assert selected_profiles(pd_job, "pd") == {
     "pd-common-test", "pd-core-test", "pd-client-test", "pd-rest-test",
 }
-assert required_test_reports(pd_job) == {
+assert reports_for_option(pd_job, "--require-test-report") == {
     "TEST-org.apache.hugegraph.pd.common.CommonSuiteTest.xml",
     "TEST-org.apache.hugegraph.pd.core.PDCoreSuiteTest.xml",
     "TEST-org.apache.hugegraph.pd.client.PDClientSuiteTest.xml",
     "TEST-org.apache.hugegraph.pd.rest.PDRestSuiteTest.xml",
 }
+assert not reports_for_option(pd_job, "--require-suite-report")
 assert required_modules(pd_job) == {
     "hg-pd-grpc", "hg-pd-common", "hg-pd-client", "hg-pd-core",
     "hg-pd-service", "hg-pd-dist",
@@ -286,10 +332,13 @@ assert_order(store_job, [
     "mvn editorconfig:check -pl hugegraph-store/hg-store-test -am -ntp",
     "-P store-common-test -Djacoco.sessionId=store-common-test",
     "-P store-client-test -Djacoco.sessionId=store-client-test",
+    "-P store-core-test -Djacoco.sessionId=store-core-test",
     "-P store-rocksdb-test -Djacoco.sessionId=store-rocksdb-test",
+    "-P store-server-test -Djacoco.sessionId=store-server-test",
     "-P store-raftcore-test -Djacoco.sessionId=store-raftcore-test",
     "mvn verify", "--require-session store-common-test",
-    "--require-session store-client-test", "--require-session store-rocksdb-test",
+    "--require-session store-client-test", "--require-session store-core-test",
+    "--require-session store-rocksdb-test", "--require-session store-server-test",
     "--require-session store-raftcore-test", "codecov/codecov-action",
 ])
 assert store_job.count("mvn clean") == 1
@@ -299,14 +348,18 @@ assert "\n          directory:" not in store_job
 assert "mvn verify -pl hugegraph-store/hg-store-test -am -P jacoco \\ " \
        "-DskipTests -Deditorconfig.skip=true -ntp" in " ".join(store_job.split())
 assert selected_profiles(store_job, "store") == {
-    "store-common-test", "store-client-test", "store-rocksdb-test",
-    "store-raftcore-test",
+    "store-common-test", "store-client-test", "store-core-test",
+    "store-rocksdb-test", "store-server-test", "store-raftcore-test",
 }
-assert required_test_reports(store_job) == {
+assert reports_for_option(store_job, "--require-test-report") == {
     "TEST-org.apache.hugegraph.store.common.CommonSuiteTest.xml",
     "TEST-org.apache.hugegraph.store.client.ClientSuiteTest.xml",
     "TEST-org.apache.hugegraph.store.rocksdb.RocksDbSuiteTest.xml",
     "TEST-org.apache.hugegraph.store.raftcore.RaftSuiteTest.xml",
+}
+assert reports_for_option(store_job, "--require-suite-report") == {
+    "TEST-org.apache.hugegraph.store.core.CoreSuiteTest.xml",
+    "TEST-org.apache.hugegraph.store.service.ServerSuiteTest.xml",
 }
 assert required_modules(store_job) == {
     "hg-store-grpc", "hg-store-common", "hg-store-client",

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
@@ -157,8 +157,14 @@ check_module("hugegraph-store", "hg-store-test")
 store_test = ET.parse(ROOT / "hugegraph-store/hg-store-test/pom.xml").getroot()
 dependencies = store_test.find(NS + "dependencies")
 assert dependencies is not None
+assert not any(child_text(dep, "artifactId") == "hg-store-rocksdb"
+               for dep in dependencies.findall(NS + "dependency"))
+store_jacoco = next(profile for profile in store_test.findall(
+    ".//" + NS + "profile") if child_text(profile, "id") == "jacoco")
+profile_dependencies = store_jacoco.find(NS + "dependencies")
+assert profile_dependencies is not None
 assert any(child_text(dep, "artifactId") == "hg-store-rocksdb"
-           for dep in dependencies.findall(NS + "dependency"))
+           for dep in profile_dependencies.findall(NS + "dependency"))
 
 workflow = (ROOT / ".github/workflows/pd-store-ci.yml").read_text()
 pd_job = workflow.split("\n  pd:\n", 1)[1].split("\n  store:\n", 1)[0]
@@ -172,6 +178,7 @@ def assert_order(job, commands):
 
 assert_order(pd_job, [
     "mvn clean package",
+    "mvn editorconfig:check -pl hugegraph-pd/hg-pd-test -am -ntp",
     "-P pd-common-test -Djacoco.sessionId=pd-common-test",
     "-P pd-core-test -Djacoco.sessionId=pd-core-test",
     "-P pd-client-test -Djacoco.sessionId=pd-client-test",
@@ -184,9 +191,12 @@ assert pd_job.count("mvn clean") == 1
 assert "hugegraph-pd/hg-pd-test/target/site/jacoco/jacoco.xml" in pd_job
 assert "files: ${{ env.REPORT_FILE }}" in pd_job
 assert "\n          directory:" not in pd_job
+assert "mvn verify -pl hugegraph-pd/hg-pd-test -am -P jacoco \\ " \
+       "-DskipTests -Deditorconfig.skip=true -ntp" in " ".join(pd_job.split())
 
 assert_order(store_job, [
     "mvn clean package",
+    "mvn editorconfig:check -pl hugegraph-store/hg-store-test -am -ntp",
     "-P store-common-test -Djacoco.sessionId=store-common-test",
     "-P store-client-test -Djacoco.sessionId=store-client-test",
     "-P store-core-test -Djacoco.sessionId=store-core-test",
@@ -202,6 +212,8 @@ assert store_job.count("mvn clean") == 1
 assert "hugegraph-store/hg-store-test/target/site/jacoco/jacoco.xml" in store_job
 assert "files: ${{ env.REPORT_FILE }}" in store_job
 assert "\n          directory:" not in store_job
+assert "mvn verify -pl hugegraph-store/hg-store-test -am -P jacoco \\ " \
+       "-DskipTests -Deditorconfig.skip=true -ntp" in " ".join(store_job.split())
 
 print("PASS: JaCoCo aggregation configuration contract")
 PY

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
@@ -38,6 +38,15 @@ run_case() {
     CASE_RC=$?
 }
 
+run_report_case() {
+    run_case --require-test-report "${TMP_DIR}/tests.xml" "$@"
+}
+
+run_case_with_timeout() {
+    CASE_OUTPUT=$(timeout 2 "${VALIDATOR}" "$@" 2>&1)
+    CASE_RC=$?
+}
+
 assert_success() {
     [[ "${CASE_RC}" -eq 0 ]] || fail "$1 returned ${CASE_RC}"
 }
@@ -54,14 +63,37 @@ if [[ ! -x "${VALIDATOR}" ]]; then
     fail "validator not found or not executable at ${VALIDATOR}"
 fi
 
+cat > "${TMP_DIR}/tests.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="SuiteTest" tests="2" failures="0" errors="0" skipped="0"/>
+EOF
+
+cat > "${TMP_DIR}/zero-tests.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="EmptySuiteTest" tests="0" failures="0" errors="0" skipped="0"/>
+EOF
+
 echo "JaCoCo report validator tests"
 
-run_case --require-session suite-a "${TMP_DIR}/missing.xml" hg-pd-client
+run_case_with_timeout --require-session
+[[ "${CASE_RC}" -ne 124 ]] || fail "missing session value timed out"
+assert_failure "missing session value"
+assert_output "--require-session requires a non-empty value"
+
+run_case --require-session ""
+assert_failure "empty session value"
+assert_output "--require-session requires a non-empty value"
+
+run_case --require-test-report
+assert_failure "missing test report value"
+assert_output "--require-test-report requires a non-empty value"
+
+run_report_case --require-session suite-a "${TMP_DIR}/missing.xml" hg-pd-client
 assert_failure "missing report"
 assert_output "not found or empty"
 
 touch "${TMP_DIR}/empty.xml"
-run_case --require-session suite-a "${TMP_DIR}/empty.xml" hg-pd-client
+run_report_case --require-session suite-a "${TMP_DIR}/empty.xml" hg-pd-client
 assert_failure "empty report"
 assert_output "not found or empty"
 
@@ -76,29 +108,52 @@ cat > "${TMP_DIR}/valid.xml" <<'EOF'
 </report>
 EOF
 
-run_case --require-session suite-a --require-session suite-b \
-         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
+run_report_case --require-session suite-a --require-session suite-b \
+                "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
 assert_success "complete report"
 assert_output "contains all expected modules"
 
-run_case --require-session suite-a --require-session suite-c \
+run_case --require-session suite-a --require-session suite-b \
          "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
+assert_failure "report without required test reports"
+assert_output "at least one --require-test-report is required"
+
+run_case --require-test-report "${TMP_DIR}/missing-tests.xml" \
+         --require-session suite-a --require-session suite-b \
+         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
+assert_failure "missing required test report"
+assert_output "Surefire report not found or empty"
+
+run_case --require-test-report "${TMP_DIR}/zero-tests.xml" \
+         --require-session suite-a --require-session suite-b \
+         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
+assert_failure "required test report without tests"
+assert_output "Surefire report has no tests"
+
+run_report_case --require-session suite-a --require-session suite-b \
+                "${TMP_DIR}/valid.xml"
+assert_failure "report without expected modules"
+assert_output "at least one expected module is required"
+
+run_report_case --require-session suite-a --require-session suite-c \
+                "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
 assert_failure "report missing a required session"
 assert_output "missing JaCoCo session 'suite-c'"
 
 sed 's/covered="3"/covered="0"/' "${TMP_DIR}/valid.xml" > "${TMP_DIR}/uncovered.xml"
-run_case --require-session suite-a --require-session suite-b \
-         "${TMP_DIR}/uncovered.xml" hg-pd-client hg-pd-core
+run_report_case --require-session suite-a --require-session suite-b \
+                "${TMP_DIR}/uncovered.xml" hg-pd-client hg-pd-core
 assert_failure "report without covered instructions"
 assert_output "has no covered instructions"
 
-run_case --require-session suite-a --require-session suite-b \
-         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-service
+run_report_case --require-session suite-a --require-session suite-b \
+                "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-service
 assert_failure "report missing an expected module"
 assert_output "missing JaCoCo group 'hg-pd-service'"
 
 python3 - "${REPO_ROOT}" <<'PY' || fail "aggregation configuration contract failed"
 from pathlib import Path
+import re
 import sys
 import xml.etree.ElementTree as ET
 
@@ -176,6 +231,25 @@ def assert_order(job, commands):
     assert positions == sorted(positions)
 
 
+def validation_command(job):
+    return job.split("$TRAVIS_DIR/check-jacoco-report.sh", 1)[1].split(
+        "- name: Upload coverage", 1)[0]
+
+
+def required_test_reports(job):
+    return set(re.findall(r"TEST-[A-Za-z0-9_.]+SuiteTest[.]xml",
+                          validation_command(job)))
+
+
+def required_modules(job):
+    command = validation_command(job).split('"$REPORT_FILE"', 1)[1]
+    return set(re.findall(r"\bhg-(?:pd|store)-[a-z0-9-]+\b", command))
+
+
+def selected_profiles(job, prefix):
+    return set(re.findall(r"-P (" + prefix + r"-[a-z0-9-]+-test)\b", job))
+
+
 assert_order(pd_job, [
     "mvn clean package",
     "mvn editorconfig:check -pl hugegraph-pd/hg-pd-test -am -ntp",
@@ -193,19 +267,29 @@ assert "files: ${{ env.REPORT_FILE }}" in pd_job
 assert "\n          directory:" not in pd_job
 assert "mvn verify -pl hugegraph-pd/hg-pd-test -am -P jacoco \\ " \
        "-DskipTests -Deditorconfig.skip=true -ntp" in " ".join(pd_job.split())
+assert selected_profiles(pd_job, "pd") == {
+    "pd-common-test", "pd-core-test", "pd-client-test", "pd-rest-test",
+}
+assert required_test_reports(pd_job) == {
+    "TEST-org.apache.hugegraph.pd.common.CommonSuiteTest.xml",
+    "TEST-org.apache.hugegraph.pd.core.PDCoreSuiteTest.xml",
+    "TEST-org.apache.hugegraph.pd.client.PDClientSuiteTest.xml",
+    "TEST-org.apache.hugegraph.pd.rest.PDRestSuiteTest.xml",
+}
+assert required_modules(pd_job) == {
+    "hg-pd-grpc", "hg-pd-common", "hg-pd-client", "hg-pd-core",
+    "hg-pd-service", "hg-pd-dist",
+}
 
 assert_order(store_job, [
     "mvn clean package",
     "mvn editorconfig:check -pl hugegraph-store/hg-store-test -am -ntp",
     "-P store-common-test -Djacoco.sessionId=store-common-test",
     "-P store-client-test -Djacoco.sessionId=store-client-test",
-    "-P store-core-test -Djacoco.sessionId=store-core-test",
     "-P store-rocksdb-test -Djacoco.sessionId=store-rocksdb-test",
-    "-P store-server-test -Djacoco.sessionId=store-server-test",
     "-P store-raftcore-test -Djacoco.sessionId=store-raftcore-test",
     "mvn verify", "--require-session store-common-test",
-    "--require-session store-client-test", "--require-session store-core-test",
-    "--require-session store-rocksdb-test", "--require-session store-server-test",
+    "--require-session store-client-test", "--require-session store-rocksdb-test",
     "--require-session store-raftcore-test", "codecov/codecov-action",
 ])
 assert store_job.count("mvn clean") == 1
@@ -214,6 +298,20 @@ assert "files: ${{ env.REPORT_FILE }}" in store_job
 assert "\n          directory:" not in store_job
 assert "mvn verify -pl hugegraph-store/hg-store-test -am -P jacoco \\ " \
        "-DskipTests -Deditorconfig.skip=true -ntp" in " ".join(store_job.split())
+assert selected_profiles(store_job, "store") == {
+    "store-common-test", "store-client-test", "store-rocksdb-test",
+    "store-raftcore-test",
+}
+assert required_test_reports(store_job) == {
+    "TEST-org.apache.hugegraph.store.common.CommonSuiteTest.xml",
+    "TEST-org.apache.hugegraph.store.client.ClientSuiteTest.xml",
+    "TEST-org.apache.hugegraph.store.rocksdb.RocksDbSuiteTest.xml",
+    "TEST-org.apache.hugegraph.store.raftcore.RaftSuiteTest.xml",
+}
+assert required_modules(store_job) == {
+    "hg-store-grpc", "hg-store-common", "hg-store-client",
+    "hg-store-rocksdb", "hg-store-core", "hg-store-node",
+}
 
 print("PASS: JaCoCo aggregation configuration contract")
 PY

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../../../../.." && pwd)
+VALIDATOR="${SCRIPT_DIR}/check-jacoco-report.sh"
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/jacoco-report-test.XXXXXX")
+CASE_OUTPUT=""
+CASE_RC=0
+
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+fail() {
+    echo "FAIL: $1" >&2
+    [[ -z "${CASE_OUTPUT}" ]] || printf '%s\n' "${CASE_OUTPUT}" >&2
+    exit 1
+}
+
+run_case() {
+    CASE_OUTPUT=$("${VALIDATOR}" "$@" 2>&1)
+    CASE_RC=$?
+}
+
+assert_success() {
+    [[ "${CASE_RC}" -eq 0 ]] || fail "$1 returned ${CASE_RC}"
+}
+
+assert_failure() {
+    [[ "${CASE_RC}" -ne 0 ]] || fail "$1 unexpectedly succeeded"
+}
+
+assert_output() {
+    [[ "${CASE_OUTPUT}" == *"$1"* ]] || fail "missing output '$1'"
+}
+
+if [[ ! -x "${VALIDATOR}" ]]; then
+    fail "validator not found or not executable at ${VALIDATOR}"
+fi
+
+echo "JaCoCo report validator tests"
+
+run_case --require-session suite-a "${TMP_DIR}/missing.xml" hg-pd-client
+assert_failure "missing report"
+assert_output "not found or empty"
+
+touch "${TMP_DIR}/empty.xml"
+run_case --require-session suite-a "${TMP_DIR}/empty.xml" hg-pd-client
+assert_failure "empty report"
+assert_output "not found or empty"
+
+cat > "${TMP_DIR}/valid.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<report name="hg-pd-test">
+  <sessioninfo id="suite-a" start="1" dump="2"/>
+  <sessioninfo id="suite-b" start="3" dump="4"/>
+  <group name="hg-pd-client"/>
+  <group name="hg-pd-core"/>
+  <counter type="INSTRUCTION" missed="7" covered="3"/>
+</report>
+EOF
+
+run_case --require-session suite-a --require-session suite-b \
+         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
+assert_success "complete report"
+assert_output "contains all expected modules"
+
+run_case --require-session suite-a --require-session suite-c \
+         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
+assert_failure "report missing a required session"
+assert_output "missing JaCoCo session 'suite-c'"
+
+sed 's/covered="3"/covered="0"/' "${TMP_DIR}/valid.xml" > "${TMP_DIR}/uncovered.xml"
+run_case --require-session suite-a --require-session suite-b \
+         "${TMP_DIR}/uncovered.xml" hg-pd-client hg-pd-core
+assert_failure "report without covered instructions"
+assert_output "has no covered instructions"
+
+run_case --require-session suite-a --require-session suite-b \
+         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-service
+assert_failure "report missing an expected module"
+assert_output "missing JaCoCo group 'hg-pd-service'"
+
+python3 - "${REPO_ROOT}" <<'PY' || fail "aggregation configuration contract failed"
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+
+ROOT = Path(sys.argv[1])
+NS = "{http://maven.apache.org/POM/4.0.0}"
+
+
+def child_text(element, name):
+    child = element.find(NS + name)
+    return "" if child is None or child.text is None else child.text.strip()
+
+
+def jacoco_plugin(container):
+    plugins = container.find(NS + "plugins")
+    assert plugins is not None
+    for plugin in plugins.findall(NS + "plugin"):
+        if child_text(plugin, "artifactId") == "jacoco-maven-plugin":
+            return plugin
+    raise AssertionError("JaCoCo plugin is missing")
+
+
+def goals(plugin):
+    return [goal.text.strip() for goal in plugin.findall(
+        ".//" + NS + "goal") if goal.text]
+
+
+def check_module(module, test_module):
+    parent = ET.parse(ROOT / module / "pom.xml").getroot()
+    parent_plugin = jacoco_plugin(parent.find(NS + "build"))
+    assert child_text(parent_plugin, "version") == "0.8.8"
+    assert child_text(parent_plugin.find(NS + "configuration"), "append") == "true"
+
+    test = ET.parse(ROOT / module / test_module / "pom.xml").getroot()
+    default_plugin = jacoco_plugin(test.find(NS + "build"))
+    assert child_text(default_plugin, "version") == "0.8.8"
+    assert "report-aggregate" not in goals(default_plugin)
+
+    profile = None
+    for candidate in test.findall(".//" + NS + "profile"):
+        if child_text(candidate, "id") == "jacoco":
+            profile = candidate
+            break
+    assert profile is not None
+    profile_plugin = jacoco_plugin(profile.find(NS + "build"))
+    assert child_text(profile_plugin, "version") == "0.8.8"
+    executions = profile_plugin.findall(".//" + NS + "execution")
+    aggregates = [execution for execution in executions
+                  if "report-aggregate" in goals(execution)]
+    assert len(aggregates) == 1
+    assert child_text(aggregates[0], "phase") == "verify"
+
+
+check_module("hugegraph-pd", "hg-pd-test")
+check_module("hugegraph-store", "hg-store-test")
+
+store_test = ET.parse(ROOT / "hugegraph-store/hg-store-test/pom.xml").getroot()
+dependencies = store_test.find(NS + "dependencies")
+assert dependencies is not None
+assert any(child_text(dep, "artifactId") == "hg-store-rocksdb"
+           for dep in dependencies.findall(NS + "dependency"))
+
+workflow = (ROOT / ".github/workflows/pd-store-ci.yml").read_text()
+pd_job = workflow.split("\n  pd:\n", 1)[1].split("\n  store:\n", 1)[0]
+store_job = workflow.split("\n  store:\n", 1)[1].split("\n  hstore:\n", 1)[0]
+
+
+def assert_order(job, commands):
+    positions = [job.index(command) for command in commands]
+    assert positions == sorted(positions)
+
+
+assert_order(pd_job, [
+    "mvn clean package",
+    "-P pd-common-test -Djacoco.sessionId=pd-common-test",
+    "-P pd-core-test -Djacoco.sessionId=pd-core-test",
+    "-P pd-client-test -Djacoco.sessionId=pd-client-test",
+    "-P pd-rest-test -Djacoco.sessionId=pd-rest-test",
+    "mvn verify", "--require-session pd-common-test",
+    "--require-session pd-core-test", "--require-session pd-client-test",
+    "--require-session pd-rest-test", "codecov/codecov-action",
+])
+assert pd_job.count("mvn clean") == 1
+assert "hugegraph-pd/hg-pd-test/target/site/jacoco/jacoco.xml" in pd_job
+assert "files: ${{ env.REPORT_FILE }}" in pd_job
+assert "\n          directory:" not in pd_job
+
+assert_order(store_job, [
+    "mvn clean package",
+    "-P store-common-test -Djacoco.sessionId=store-common-test",
+    "-P store-client-test -Djacoco.sessionId=store-client-test",
+    "-P store-core-test -Djacoco.sessionId=store-core-test",
+    "-P store-rocksdb-test -Djacoco.sessionId=store-rocksdb-test",
+    "-P store-server-test -Djacoco.sessionId=store-server-test",
+    "-P store-raftcore-test -Djacoco.sessionId=store-raftcore-test",
+    "mvn verify", "--require-session store-common-test",
+    "--require-session store-client-test", "--require-session store-core-test",
+    "--require-session store-rocksdb-test", "--require-session store-server-test",
+    "--require-session store-raftcore-test", "codecov/codecov-action",
+])
+assert store_job.count("mvn clean") == 1
+assert "hugegraph-store/hg-store-test/target/site/jacoco/jacoco.xml" in store_job
+assert "files: ${{ env.REPORT_FILE }}" in store_job
+assert "\n          directory:" not in store_job
+
+print("PASS: JaCoCo aggregation configuration contract")
+PY
+
+echo "PASS: JaCoCo report validator contract"

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
@@ -43,7 +43,41 @@ run_report_case() {
 }
 
 run_case_with_timeout() {
-    CASE_OUTPUT=$(timeout 2 "${VALIDATOR}" "$@" 2>&1)
+    CASE_OUTPUT=$(python3 - "${VALIDATOR}" "$@" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+process = subprocess.Popen(
+    sys.argv[1:],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    universal_newlines=True,
+    start_new_session=True,
+)
+try:
+    output, _ = process.communicate(timeout=2)
+except subprocess.TimeoutExpired:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        output, _ = process.communicate(timeout=1)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        output, _ = process.communicate()
+    sys.stdout.write(output)
+    sys.exit(124)
+
+sys.stdout.write(output)
+sys.exit(process.returncode)
+PY
+    )
     CASE_RC=$?
 }
 
@@ -73,17 +107,61 @@ cat > "${TMP_DIR}/zero-tests.xml" <<'EOF'
 <testsuite name="EmptySuiteTest" tests="0" failures="0" errors="0" skipped="0"/>
 EOF
 
+cat > "${TMP_DIR}/all-skipped.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="AllSkippedSuiteTest" tests="2" failures="0" errors="0" skipped="2"/>
+EOF
+
 cat > "${TMP_DIR}/not-surefire.xml" <<'EOF'
 <?xml version="1.0" encoding="UTF-8"?>
 <report tests="0"/>
 EOF
 
+cat > "${TMP_DIR}/hanging-validator.sh" <<'EOF'
+#!/bin/bash
+sleep 30 >/dev/null 2>&1 &
+child_pid=$!
+printf '%s\n' "${child_pid}" > "${1}"
+wait "${child_pid}"
+EOF
+chmod +x "${TMP_DIR}/hanging-validator.sh"
+
 echo "JaCoCo report validator tests"
 
+# Simulate stock macOS, where GNU timeout is not installed by default.
+timeout() {
+    return 127
+}
 run_case_with_timeout --require-session
+unset -f timeout
 [[ "${CASE_RC}" -ne 124 ]] || fail "missing session value timed out"
 assert_failure "missing session value"
 assert_output "--require-session requires a non-empty value"
+
+REAL_VALIDATOR="${VALIDATOR}"
+VALIDATOR="${TMP_DIR}/hanging-validator.sh"
+run_case_with_timeout "${TMP_DIR}/hanging-child.pid"
+VALIDATOR="${REAL_VALIDATOR}"
+[[ "${CASE_RC}" -eq 124 ]] || fail "hanging validator returned ${CASE_RC}"
+child_pid=$(cat "${TMP_DIR}/hanging-child.pid")
+if ! python3 - "${child_pid}" <<'PY'
+import os
+import sys
+import time
+
+pid = int(sys.argv[1])
+for _ in range(20):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        sys.exit(0)
+    time.sleep(0.05)
+sys.exit(1)
+PY
+then
+    kill "${child_pid}" 2>/dev/null || true
+    fail "timed-out validator left child process ${child_pid} running"
+fi
 
 run_case --require-session ""
 assert_failure "empty session value"
@@ -226,6 +304,12 @@ run_case --require-test-report "${TMP_DIR}/zero-tests.xml" \
          "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
 assert_failure "required test report without tests"
 assert_output "Surefire report has no tests"
+
+run_case --require-test-report "${TMP_DIR}/all-skipped.xml" \
+         --require-session suite-a --require-session suite-b \
+         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
+assert_failure "required all-skipped test report"
+assert_output "Surefire report has no executed tests"
 
 run_case --require-test-report "${TMP_DIR}/not-surefire.xml" \
          --require-session suite-a --require-session suite-b \

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
@@ -93,6 +93,14 @@ run_case --require-test-report
 assert_failure "missing test report value"
 assert_output "--require-test-report requires a non-empty value"
 
+run_case --require-covered-group
+assert_failure "missing covered group value"
+assert_output "--require-covered-group requires a non-empty value"
+
+run_case --require-covered-group ""
+assert_failure "empty covered group value"
+assert_output "--require-covered-group requires a non-empty value"
+
 run_case --require-suite-report
 assert_failure "removed suite report option"
 assert_output "unknown option: --require-suite-report"
@@ -149,6 +157,21 @@ cat > "${TMP_DIR}/truncated.xml" <<'EOF'
   <counter type="INSTRUCTION" missed="7" covered="3"/>
 EOF
 
+cat > "${TMP_DIR}/partial-group-coverage.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<report name="partial-group-coverage">
+  <sessioninfo id="suite-a" start="1" dump="2"/>
+  <sessioninfo id="suite-b" start="3" dump="4"/>
+  <group name="hg-pd-core">
+    <counter type="INSTRUCTION" missed="10" covered="0"/>
+  </group>
+  <group name="hg-pd-service">
+    <counter type="INSTRUCTION" missed="2" covered="5"/>
+  </group>
+  <counter type="INSTRUCTION" missed="12" covered="5"/>
+</report>
+EOF
+
 run_report_case --require-session suite-a --require-session suite-b \
                 "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
 assert_success "complete report"
@@ -167,6 +190,25 @@ run_report_case --require-session suite-a --require-session suite-b \
                 "${TMP_DIR}/comment-only.xml" hg-pd-client hg-pd-core
 assert_failure "report with evidence only in XML comments"
 assert_output "has no covered instructions"
+
+run_report_case --require-session suite-a --require-session suite-b \
+                "${TMP_DIR}/partial-group-coverage.xml" \
+                hg-pd-core hg-pd-service
+assert_success "presence-only groups with partial coverage"
+
+run_report_case --require-covered-group hg-pd-service \
+                --require-session suite-a --require-session suite-b \
+                "${TMP_DIR}/partial-group-coverage.xml" \
+                hg-pd-core hg-pd-service
+assert_success "required group with covered instructions"
+
+run_report_case --require-covered-group hg-pd-core \
+                --require-covered-group hg-pd-service \
+                --require-session suite-a --require-session suite-b \
+                "${TMP_DIR}/partial-group-coverage.xml" \
+                hg-pd-core hg-pd-service
+assert_failure "required group without covered instructions"
+assert_output "JaCoCo group 'hg-pd-core' has no covered instructions"
 
 run_case --require-session suite-a --require-session suite-b \
          "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
@@ -305,6 +347,11 @@ def reports_for_option(job, option):
     return set(re.findall(pattern, validation_command(job)))
 
 
+def values_for_option(job, option):
+    pattern = re.escape(option) + r"\s+([A-Za-z0-9_-]+)"
+    return set(re.findall(pattern, validation_command(job)))
+
+
 def required_modules(job):
     command = validation_command(job).split('"$REPORT_FILE"', 1)[1]
     return set(re.findall(r"\bhg-(?:pd|store)-[a-z0-9-]+\b", command))
@@ -341,6 +388,9 @@ assert reports_for_option(pd_job, "--require-test-report") == {
     "TEST-org.apache.hugegraph.pd.rest.PDRestSuiteTest.xml",
 }
 assert not reports_for_option(pd_job, "--require-suite-report")
+assert values_for_option(pd_job, "--require-covered-group") == {
+    "hg-pd-common", "hg-pd-client", "hg-pd-core",
+}
 assert required_modules(pd_job) == {
     "hg-pd-grpc", "hg-pd-common", "hg-pd-client", "hg-pd-core",
     "hg-pd-service", "hg-pd-dist",
@@ -374,6 +424,9 @@ assert reports_for_option(store_job, "--require-test-report") == {
     "TEST-org.apache.hugegraph.store.raftcore.RaftSuiteTest.xml",
 }
 assert not reports_for_option(store_job, "--require-suite-report")
+assert values_for_option(store_job, "--require-covered-group") == {
+    "hg-store-common", "hg-store-client", "hg-store-rocksdb",
+}
 assert required_modules(store_job) == {
     "hg-store-grpc", "hg-store-common", "hg-store-client",
     "hg-store-rocksdb",

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
@@ -94,12 +94,8 @@ assert_failure "missing test report value"
 assert_output "--require-test-report requires a non-empty value"
 
 run_case --require-suite-report
-assert_failure "missing suite report value"
-assert_output "--require-suite-report requires a non-empty value"
-
-run_case --require-suite-report ""
-assert_failure "empty suite report value"
-assert_output "--require-suite-report requires a non-empty value"
+assert_failure "removed suite report option"
+assert_output "unknown option: --require-suite-report"
 
 run_report_case --require-session suite-a "${TMP_DIR}/missing.xml" hg-pd-client
 assert_failure "missing report"
@@ -121,10 +117,56 @@ cat > "${TMP_DIR}/valid.xml" <<'EOF'
 </report>
 EOF
 
+cat > "${TMP_DIR}/comment-only.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<report name="comment-only">
+  <!-- <sessioninfo id="suite-a" start="1" dump="2"/> -->
+  <!-- <sessioninfo id="suite-b" start="3" dump="4"/> -->
+  <!-- <group name="hg-pd-client"/> -->
+  <!-- <group name="hg-pd-core"/> -->
+  <!-- <counter type="INSTRUCTION" missed="7" covered="3"/> -->
+</report>
+EOF
+
+cat > "${TMP_DIR}/reordered.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<report name="reordered">
+  <sessioninfo start="1" dump="2" id="suite-a"/>
+  <sessioninfo dump="4" id="suite-b" start="3"/>
+  <group name="hg-pd-client"/>
+  <group name="hg-pd-core"/>
+  <counter covered="3" type="INSTRUCTION" missed="7"/>
+</report>
+EOF
+
+cat > "${TMP_DIR}/truncated.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<report name="truncated">
+  <sessioninfo id="suite-a" start="1" dump="2"/>
+  <sessioninfo id="suite-b" start="3" dump="4"/>
+  <group name="hg-pd-client"/>
+  <group name="hg-pd-core"/>
+  <counter type="INSTRUCTION" missed="7" covered="3"/>
+EOF
+
 run_report_case --require-session suite-a --require-session suite-b \
                 "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
 assert_success "complete report"
 assert_output "contains all expected modules"
+
+run_report_case --require-session suite-a --require-session suite-b \
+                "${TMP_DIR}/truncated.xml" hg-pd-client hg-pd-core
+assert_failure "truncated JaCoCo report"
+assert_output "unable to parse JaCoCo report"
+
+run_report_case --require-session suite-a --require-session suite-b \
+                "${TMP_DIR}/reordered.xml" hg-pd-client hg-pd-core
+assert_success "report with reordered XML attributes"
+
+run_report_case --require-session suite-a --require-session suite-b \
+                "${TMP_DIR}/comment-only.xml" hg-pd-client hg-pd-core
+assert_failure "report with evidence only in XML comments"
+assert_output "has no covered instructions"
 
 run_case --require-session suite-a --require-session suite-b \
          "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
@@ -143,24 +185,10 @@ run_case --require-test-report "${TMP_DIR}/zero-tests.xml" \
 assert_failure "required test report without tests"
 assert_output "Surefire report has no tests"
 
-run_case --require-suite-report "${TMP_DIR}/zero-tests.xml" \
-         --require-test-report "${TMP_DIR}/tests.xml" \
+run_case --require-test-report "${TMP_DIR}/not-surefire.xml" \
          --require-session suite-a --require-session suite-b \
          "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
-assert_success "required zero-test suite report"
-
-run_case --require-suite-report "${TMP_DIR}/missing-suite.xml" \
-         --require-test-report "${TMP_DIR}/tests.xml" \
-         --require-session suite-a --require-session suite-b \
-         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
-assert_failure "missing required suite report"
-assert_output "Surefire report not found or empty"
-
-run_case --require-suite-report "${TMP_DIR}/not-surefire.xml" \
-         --require-test-report "${TMP_DIR}/tests.xml" \
-         --require-session suite-a --require-session suite-b \
-         "${TMP_DIR}/valid.xml" hg-pd-client hg-pd-core
-assert_failure "required suite report with invalid root"
+assert_failure "required test report with invalid root"
 assert_output "unable to parse Surefire report"
 
 run_report_case --require-session suite-a --require-session suite-b \
@@ -254,15 +282,6 @@ assert profile_dependencies is not None
 assert any(child_text(dep, "artifactId") == "hg-store-rocksdb"
            for dep in profile_dependencies.findall(NS + "dependency"))
 
-core_suite = (ROOT / "hugegraph-store/hg-store-test/src/main/java/org/apache/"
-              "hugegraph/store/core/CoreSuiteTest.java").read_text()
-core_suite_code = "\n".join(
-    line for line in core_suite.splitlines()
-    if not line.lstrip().startswith("//")
-)
-assert "@RunWith(Suite.class)" in core_suite_code
-assert re.search(r"@Suite[.]SuiteClasses[(][{]\s*[}][)]", core_suite_code)
-
 workflow = (ROOT / ".github/workflows/pd-store-ci.yml").read_text()
 pd_job = workflow.split("\n  pd:\n", 1)[1].split("\n  store:\n", 1)[0]
 store_job = workflow.split("\n  store:\n", 1)[1].split("\n  hstore:\n", 1)[0]
@@ -332,13 +351,10 @@ assert_order(store_job, [
     "mvn editorconfig:check -pl hugegraph-store/hg-store-test -am -ntp",
     "-P store-common-test -Djacoco.sessionId=store-common-test",
     "-P store-client-test -Djacoco.sessionId=store-client-test",
-    "-P store-core-test -Djacoco.sessionId=store-core-test",
     "-P store-rocksdb-test -Djacoco.sessionId=store-rocksdb-test",
-    "-P store-server-test -Djacoco.sessionId=store-server-test",
     "-P store-raftcore-test -Djacoco.sessionId=store-raftcore-test",
     "mvn verify", "--require-session store-common-test",
-    "--require-session store-client-test", "--require-session store-core-test",
-    "--require-session store-rocksdb-test", "--require-session store-server-test",
+    "--require-session store-client-test", "--require-session store-rocksdb-test",
     "--require-session store-raftcore-test", "codecov/codecov-action",
 ])
 assert store_job.count("mvn clean") == 1
@@ -348,8 +364,8 @@ assert "\n          directory:" not in store_job
 assert "mvn verify -pl hugegraph-store/hg-store-test -am -P jacoco \\ " \
        "-DskipTests -Deditorconfig.skip=true -ntp" in " ".join(store_job.split())
 assert selected_profiles(store_job, "store") == {
-    "store-common-test", "store-client-test", "store-core-test",
-    "store-rocksdb-test", "store-server-test", "store-raftcore-test",
+    "store-common-test", "store-client-test", "store-rocksdb-test",
+    "store-raftcore-test",
 }
 assert reports_for_option(store_job, "--require-test-report") == {
     "TEST-org.apache.hugegraph.store.common.CommonSuiteTest.xml",
@@ -357,13 +373,10 @@ assert reports_for_option(store_job, "--require-test-report") == {
     "TEST-org.apache.hugegraph.store.rocksdb.RocksDbSuiteTest.xml",
     "TEST-org.apache.hugegraph.store.raftcore.RaftSuiteTest.xml",
 }
-assert reports_for_option(store_job, "--require-suite-report") == {
-    "TEST-org.apache.hugegraph.store.core.CoreSuiteTest.xml",
-    "TEST-org.apache.hugegraph.store.service.ServerSuiteTest.xml",
-}
+assert not reports_for_option(store_job, "--require-suite-report")
 assert required_modules(store_job) == {
     "hg-store-grpc", "hg-store-common", "hg-store-client",
-    "hg-store-rocksdb", "hg-store-core", "hg-store-node",
+    "hg-store-rocksdb",
 }
 
 print("PASS: JaCoCo aggregation configuration contract")

--- a/hugegraph-store/hg-store-test/pom.xml
+++ b/hugegraph-store/hg-store-test/pom.xml
@@ -39,6 +39,13 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.hugegraph</groupId>
+                    <artifactId>hg-store-rocksdb</artifactId>
+                    <version>${revision}</version>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -75,11 +82,6 @@
         <dependency>
             <groupId>org.apache.hugegraph</groupId>
             <artifactId>hg-store-common</artifactId>
-            <version>${revision}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hugegraph</groupId>
-            <artifactId>hg-store-rocksdb</artifactId>
             <version>${revision}</version>
         </dependency>
         <dependency>

--- a/hugegraph-store/hg-store-test/pom.xml
+++ b/hugegraph-store/hg-store-test/pom.xml
@@ -44,17 +44,18 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.4</version>
+                        <version>0.8.8</version>
 
                         <executions>
                             <execution>
-                                <id>default</id>
+                                <id>coverage-report</id>
                                 <phase>verify</phase>
                                 <goals>
                                     <goal>report-aggregate</goal>
                                 </goals>
                                 <configuration>
-                                    <outputDirectory>${project.basedir}/../target/site/jacoco
+                                    <outputDirectory>
+                                        ${project.basedir}/target/site/jacoco
                                     </outputDirectory>
                                 </configuration>
                             </execution>
@@ -74,6 +75,11 @@
         <dependency>
             <groupId>org.apache.hugegraph</groupId>
             <artifactId>hg-store-common</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hugegraph</groupId>
+            <artifactId>hg-store-rocksdb</artifactId>
             <version>${revision}</version>
         </dependency>
         <dependency>
@@ -295,26 +301,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
-                <executions>
-                    <execution>
-                        <id>pre-test</id>
-
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>post-test</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report-aggregate</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${basedir}/target/site/jacoco</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/grpc/**/*</exclude>

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/core/CoreSuiteTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/core/CoreSuiteTest.java
@@ -17,14 +17,11 @@
 
 package org.apache.hugegraph.store.core;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-
 import lombok.extern.slf4j.Slf4j;
 
 // TODO: uncomment it until all test can run free.
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+//@RunWith(Suite.class)
+//@Suite.SuiteClasses({
 //        HgCmdClientTest.class,
 //        HgSnapshotHandlerTest.class,
 //        RaftUtilsTest.class,
@@ -44,7 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 //        PartitionInstructionProcessorTest.class,
 //        // Try to put it last
 //        HgBusinessImplTest.class
-})
+//})
 
 @Slf4j
 public class CoreSuiteTest {

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/core/CoreSuiteTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/core/CoreSuiteTest.java
@@ -17,11 +17,14 @@
 
 package org.apache.hugegraph.store.core;
 
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
 import lombok.extern.slf4j.Slf4j;
 
 // TODO: uncomment it until all test can run free.
-//@RunWith(Suite.class)
-//@Suite.SuiteClasses({
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
 //        HgCmdClientTest.class,
 //        HgSnapshotHandlerTest.class,
 //        RaftUtilsTest.class,
@@ -41,7 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 //        PartitionInstructionProcessorTest.class,
 //        // Try to put it last
 //        HgBusinessImplTest.class
-//})
+})
 
 @Slf4j
 public class CoreSuiteTest {

--- a/hugegraph-store/pom.xml
+++ b/hugegraph-store/pom.xml
@@ -98,7 +98,10 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
+                <configuration>
+                    <append>true</append>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
## Purpose of the PR

- close #3160

PD and Store CI run several Maven test profiles in separate invocations, but
each invocation previously replaced JaCoCo execution data and generated a
partial report. PD also ran `mvn clean package` after two coverage-producing
test profiles, deleting their data before upload. As a result, Codecov could
receive only the last profile's coverage or an imprecisely selected report.

The existing JaCoCo 0.8.4 configuration also cannot instrument Java 17 class
files, which blocks the project's planned Java 17 migration.

## Main Changes

- Move the PD clean/package step before all coverage-producing test profiles.
- Upgrade PD and Store JaCoCo plugins from 0.8.4 to 0.8.8 and append execution
  data across Maven invocations.
- Assign a deterministic JaCoCo session ID to every selected PD/Store test
  profile and verify the complete expected session set before upload.
- Require at least one non-skipped Surefire test for every selected suite.
  Exclude the existing Store core/server placeholder suites from the coverage
  gate until they contain real tests.
- Generate one aggregate XML report during `verify` and upload that exact file
  to Codecov.
- Parse the aggregate JaCoCo XML structurally, rejecting malformed XML and
  comment-only evidence while accepting valid attribute reordering.
- Require non-zero instruction coverage for the instrumented PD common/client/
  core groups and Store common/client/RocksDB groups. Keep zero-class and
  externally executed aggregate dependencies as presence-only checks.
- Include `hg-store-rocksdb` as a direct report-aggregate dependency only in
  the `jacoco` profile so normal Store test dependency resolution is unchanged.
- Run EditorConfig before tests create RocksDB runtime files, then skip only
  that already-completed check during the final aggregate-only `verify`.
- Add validator and contract tests for malformed arguments, missing reports,
  zero-test and all-skipped suites, malformed and spoofed XML, reordered
  attributes, uncovered reports and individual required groups, missing
  sessions/modules, Maven lifecycle bindings, dependency scope, exact workflow
  inputs, and timeout behavior without GNU coreutils.

## Verifying these changes

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - `hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh`
    - Parse `.github/workflows/pd-store-ci.yml` and all changed POMs.
    - `mvn -q apache-rat:check -N -ntp`
    - `mvn editorconfig:check -pl hugegraph-server/hugegraph-dist -am -ntp`
    - `mvn editorconfig:check -pl hugegraph-pd/hg-pd-test -am -ntp`
    - `mvn editorconfig:check -pl hugegraph-store/hg-store-test -am -ntp`
    - `mvn verify -pl hugegraph-pd/hg-pd-test -am -P jacoco -DskipTests -Deditorconfig.skip=true -ntp`
    - `mvn verify -pl hugegraph-store/hg-store-test -am -P jacoco -DskipTests -Deditorconfig.skip=true -ntp`
    - Verify the normal Store dependency tree still resolves PowerMock's
      `org.javassist:javassist:3.24.0-GA`.
    - Java 17 smoke: JaCoCo 0.8.4 rejects class-file major version 61, while
      0.8.8 instruments the same class and writes execution data successfully.

The complete four-suite PD/four-suite Store workflow and the external Codecov
upload are left to GitHub Actions because the local environment uses JDK 17
while this workflow currently installs JDK 11.

## Does this PR potentially affect the following parts?

- [ ] Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh))
- [x] Modify configurations
- [ ] The public API
- [x] Other affects (PD/Store CI coverage collection and upload)
- [ ] Nope

## Documentation Status

- [ ] `Doc - TODO`
- [ ] `Doc - Done`
- [x] `Doc - No Need`
