### PR TITLE
fix(ci): modernize Codecov uploads

### DIFF
--- a/.github/workflows/commons-ci.yml
+++ b/.github/workflows/commons-ci.yml
@@ -58,6 +58,9 @@ jobs:
           mvn test -pl hugegraph-commons/hugegraph-rpc -Dtest=UnitTestSuite -DskipCommonsTests=false
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.0.0
+        uses: codecov/codecov-action@v5
         with:
-          file: target/jacoco.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: hugegraph-commons/target/jacoco.xml
+          disable_search: true
+          fail_ci_if_error: false

--- a/.github/workflows/pd-store-ci.yml
+++ b/.github/workflows/pd-store-ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run JaCoCo report validator tests
         run: hugegraph-server/hugegraph-dist/src/assembly/travis/test-check-jacoco-report.sh
 
+      - name: Run Codecov upload configuration tests
+        run: hugegraph-server/hugegraph-dist/src/assembly/travis/test-codecov-upload-config.sh
+
       - name: Use staged maven repo settings
         run: |
           cp $HOME/.m2/settings.xml /tmp/settings.xml || true
@@ -184,9 +187,12 @@ jobs:
             hg-pd-grpc hg-pd-common hg-pd-client hg-pd-core hg-pd-service hg-pd-dist
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.0.0
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.REPORT_FILE }}
+          disable_search: true
+          fail_ci_if_error: false
 
   store:
     needs: struct
@@ -316,9 +322,12 @@ jobs:
             hg-store-grpc hg-store-common hg-store-client hg-store-rocksdb
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.0.0
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.REPORT_FILE }}
+          disable_search: true
+          fail_ci_if_error: false
 
   hstore:
     needs: struct
@@ -387,6 +396,9 @@ jobs:
           $TRAVIS_DIR/run-tinkerpop-test.sh $BACKEND tinkerpop
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.0.0
+        uses: codecov/codecov-action@v5
         with:
-          file: ${{ env.REPORT_DIR }}/*.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ env.REPORT_DIR }}/*.xml
+          disable_search: true
+          fail_ci_if_error: false

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -216,11 +216,12 @@ jobs:
           $TRAVIS_DIR/run-tinkerpop-test.sh $BACKEND tinkerpop
 
       - name: Upload coverage to Codecov
-        # TODO: update to v5 later
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ${{ env.REPORT_DIR }}/*.xml
+          files: ${{ env.REPORT_DIR }}/*.xml
+          disable_search: true
+          fail_ci_if_error: false
 
   build-server-macos-rocksdb:
     runs-on: ${{ matrix.os }}

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-codecov-upload-config.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-codecov-upload-config.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../../../../.." && pwd)
+
+python3 - "${REPO_ROOT}" <<'PY'
+import pathlib
+import re
+import sys
+
+repo_root = pathlib.Path(sys.argv[1])
+expected_uploads = {
+    ".github/workflows/commons-ci.yml": 1,
+    ".github/workflows/pd-store-ci.yml": 3,
+    ".github/workflows/server-ci.yml": 1,
+}
+action_pattern = re.compile(
+    r"^(?P<indent>\s*)(?P<dash>-\s+)?uses:\s*"
+    r"codecov/codecov-action@(?P<version>\S+)\s*$"
+)
+version_pattern = re.compile(r"^v(?P<major>\d+)(?:[.-].*)?$")
+errors = []
+workflow_dir = repo_root / ".github/workflows"
+workflow_paths = sorted(
+    set(workflow_dir.glob("*.yml")) | set(workflow_dir.glob("*.yaml"))
+)
+checked_expected_workflows = set()
+
+
+def indentation(line):
+    return len(line) - len(line.lstrip())
+
+
+for workflow_path in workflow_paths:
+    relative_path = str(workflow_path.relative_to(repo_root))
+    lines = workflow_path.read_text(encoding="utf-8").splitlines()
+    uploads = []
+
+    for line_number, line in enumerate(lines, start=1):
+        match = action_pattern.match(line)
+        if match is None:
+            continue
+
+        uses_indent = len(match.group("indent"))
+        if match.group("dash") is not None:
+            uses_indent += len(match.group("dash"))
+        step_indent = uses_indent - 2
+        block = []
+        for candidate in lines[line_number:]:
+            if candidate.strip() and indentation(candidate) <= step_indent:
+                break
+            block.append(candidate)
+        uploads.append((line_number, match.group("version"), block))
+
+    expected_count = expected_uploads.get(relative_path)
+    if expected_count is not None and len(uploads) != expected_count:
+        errors.append(
+            f"{relative_path}: expected {expected_count} Codecov uploads, "
+            f"found {len(uploads)}"
+        )
+    if expected_count is not None:
+        checked_expected_workflows.add(relative_path)
+
+    for line_number, version, block in uploads:
+        version_match = version_pattern.match(version)
+        if version_match is None or int(version_match.group("major")) < 5:
+            errors.append(
+                f"{relative_path}:{line_number}: Codecov action {version} "
+                "uses the legacy uploader"
+            )
+
+        inputs = {}
+        in_with_block = False
+        for candidate in block:
+            candidate_indent = indentation(candidate)
+            if candidate_indent == uses_indent and candidate.strip() == "with:":
+                in_with_block = True
+                continue
+            if (in_with_block and candidate.strip() and
+                    candidate_indent <= uses_indent):
+                break
+            if not in_with_block or candidate_indent != uses_indent + 2:
+                continue
+            candidate_match = re.match(
+                r"^\s*(?P<key>[a-zA-Z_]+):\s*(?P<value>.*?)\s*$",
+                candidate,
+            )
+            if candidate_match is not None:
+                inputs[candidate_match.group("key")] = candidate_match.group("value")
+
+        if not inputs.get("files"):
+            errors.append(
+                f"{relative_path}:{line_number}: Codecov upload must use "
+                "the files input"
+            )
+        if inputs.get("token") != "${{ secrets.CODECOV_TOKEN }}":
+            errors.append(
+                f"{relative_path}:{line_number}: Codecov upload must pass "
+                "secrets.CODECOV_TOKEN for trusted runs"
+            )
+
+for relative_path in expected_uploads.keys() - checked_expected_workflows:
+    errors.append(f"{relative_path}: expected workflow file is missing")
+
+if errors:
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    sys.exit(1)
+
+print("PASS: Codecov upload configuration contract")
+PY

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-codecov-upload-config.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-codecov-upload-config.sh
@@ -49,9 +49,7 @@ def indentation(line):
     return len(line) - len(line.lstrip())
 
 
-for workflow_path in workflow_paths:
-    relative_path = str(workflow_path.relative_to(repo_root))
-    lines = workflow_path.read_text(encoding="utf-8").splitlines()
+def find_uploads(lines):
     uploads = []
 
     for line_number, line in enumerate(lines, start=1):
@@ -68,7 +66,81 @@ for workflow_path in workflow_paths:
             if candidate.strip() and indentation(candidate) <= step_indent:
                 break
             block.append(candidate)
-        uploads.append((line_number, match.group("version"), block))
+        uploads.append(
+            (line_number, match.group("version"), block, uses_indent)
+        )
+
+    return uploads
+
+
+def read_inputs(block, uses_indent):
+    inputs = {}
+    in_with_block = False
+    for candidate in block:
+        candidate_indent = indentation(candidate)
+        if candidate_indent == uses_indent and candidate.strip() == "with:":
+            in_with_block = True
+            continue
+        if (in_with_block and candidate.strip() and
+                candidate_indent <= uses_indent):
+            break
+        if not in_with_block or candidate_indent != uses_indent + 2:
+            continue
+        candidate_match = re.match(
+            r"^\s*(?P<key>[a-zA-Z_]+):\s*(?P<value>.*?)\s*$",
+            candidate,
+        )
+        if candidate_match is not None:
+            inputs[candidate_match.group("key")] = candidate_match.group("value")
+    return inputs
+
+
+def parse_uploads(lines):
+    return [
+        (line_number, version, read_inputs(block, uses_indent))
+        for line_number, version, block, uses_indent in find_uploads(lines)
+    ]
+
+
+def check_mixed_upload_indentation():
+    lines = [
+        "jobs:",
+        "  first:",
+        "    steps:",
+        "      - uses: codecov/codecov-action@v5",
+        "        with:",
+        "          token: ${{ secrets.CODECOV_TOKEN }}",
+        "          files: first.xml",
+        "  second:",
+        "      steps:",
+        "        - uses: codecov/codecov-action@v5",
+        "          with:",
+        "            token: ${{ secrets.CODECOV_TOKEN }}",
+        "            files: second.xml",
+    ]
+    expected_inputs = [
+        {
+            "token": "${{ secrets.CODECOV_TOKEN }}",
+            "files": "first.xml",
+        },
+        {
+            "token": "${{ secrets.CODECOV_TOKEN }}",
+            "files": "second.xml",
+        },
+    ]
+    actual_inputs = [inputs for _, _, inputs in parse_uploads(lines)]
+    if actual_inputs != expected_inputs:
+        return ["Codecov uploads with mixed indentation were parsed incorrectly"]
+    return []
+
+
+errors.extend(check_mixed_upload_indentation())
+
+
+for workflow_path in workflow_paths:
+    relative_path = str(workflow_path.relative_to(repo_root))
+    lines = workflow_path.read_text(encoding="utf-8").splitlines()
+    uploads = parse_uploads(lines)
 
     expected_count = expected_uploads.get(relative_path)
     if expected_count is not None and len(uploads) != expected_count:
@@ -79,32 +151,13 @@ for workflow_path in workflow_paths:
     if expected_count is not None:
         checked_expected_workflows.add(relative_path)
 
-    for line_number, version, block in uploads:
+    for line_number, version, inputs in uploads:
         version_match = version_pattern.match(version)
         if version_match is None or int(version_match.group("major")) < 5:
             errors.append(
                 f"{relative_path}:{line_number}: Codecov action {version} "
                 "uses the legacy uploader"
             )
-
-        inputs = {}
-        in_with_block = False
-        for candidate in block:
-            candidate_indent = indentation(candidate)
-            if candidate_indent == uses_indent and candidate.strip() == "with:":
-                in_with_block = True
-                continue
-            if (in_with_block and candidate.strip() and
-                    candidate_indent <= uses_indent):
-                break
-            if not in_with_block or candidate_indent != uses_indent + 2:
-                continue
-            candidate_match = re.match(
-                r"^\s*(?P<key>[a-zA-Z_]+):\s*(?P<value>.*?)\s*$",
-                candidate,
-            )
-            if candidate_match is not None:
-                inputs[candidate_match.group("key")] = candidate_match.group("value")
 
         if not inputs.get("files"):
             errors.append(

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-codecov-upload-config.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-codecov-upload-config.sh
@@ -25,30 +25,29 @@ python3 - "${REPO_ROOT}" <<'PY'
 import pathlib
 import re
 import sys
+from collections import Counter
 
 repo_root = pathlib.Path(sys.argv[1])
-expected_uploads = {
-    ".github/workflows/commons-ci.yml": 1,
-    ".github/workflows/pd-store-ci.yml": 3,
-    ".github/workflows/server-ci.yml": 1,
-}
 expected_files = {
-    ".github/workflows/commons-ci.yml": [
-        "hugegraph-commons/target/jacoco.xml",
-    ],
-    ".github/workflows/pd-store-ci.yml": [
-        "${{ env.REPORT_FILE }}",
-        "${{ env.REPORT_FILE }}",
-        "${{ env.REPORT_DIR }}/*.xml",
-    ],
-    ".github/workflows/server-ci.yml": [
-        "${{ env.REPORT_DIR }}/*.xml",
-    ],
+    ".github/workflows/commons-ci.yml": {
+        "build-commons": "hugegraph-commons/target/jacoco.xml",
+    },
+    ".github/workflows/pd-store-ci.yml": {
+        "pd": "${{ env.REPORT_FILE }}",
+        "store": "${{ env.REPORT_FILE }}",
+        "hstore": "${{ env.REPORT_DIR }}/*.xml",
+    },
+    ".github/workflows/server-ci.yml": {
+        "build-server": "${{ env.REPORT_DIR }}/*.xml",
+    },
 }
 action_pattern = re.compile(
     r"^(?P<indent>\s*)(?P<dash>-\s+)?uses:\s*"
-    r"codecov/codecov-action@(?P<version>\S+)\s*$"
+    r"(?:(?P<quote>['\"])codecov/codecov-action@"
+    r"(?P<quoted>[^'\"\s]+)(?P=quote)\s*(?:#.*)?|"
+    r"codecov/codecov-action@(?P<plain>\S+?)(?:\s+#.*)?\s*)$"
 )
+job_pattern = re.compile(r"^  (?P<job>[a-zA-Z0-9_-]+):\s*(?:#.*)?$")
 version_pattern = re.compile(r"^v(?P<major>\d+)(?:[.-].*)?$")
 errors = []
 workflow_dir = repo_root / ".github/workflows"
@@ -64,8 +63,12 @@ def indentation(line):
 
 def find_uploads(lines):
     uploads = []
+    current_job = None
 
     for line_number, line in enumerate(lines, start=1):
+        job_match = job_pattern.match(line)
+        if job_match is not None:
+            current_job = job_match.group("job")
         match = action_pattern.match(line)
         if match is None:
             continue
@@ -80,7 +83,8 @@ def find_uploads(lines):
                 break
             block.append(candidate)
         uploads.append(
-            (line_number, match.group("version"), block, uses_indent)
+            (line_number, current_job,
+             match.group("quoted") or match.group("plain"), block, uses_indent)
         )
 
     return uploads
@@ -110,9 +114,16 @@ def read_inputs(block, uses_indent):
 
 def parse_uploads(lines):
     return [
-        (line_number, version, read_inputs(block, uses_indent))
-        for line_number, version, block, uses_indent in find_uploads(lines)
+        (line_number, job, version, read_inputs(block, uses_indent))
+        for line_number, job, version, block, uses_indent in find_uploads(lines)
     ]
+
+
+def files_match(uploads, expected):
+    actual = Counter(
+        (job, inputs.get("files")) for _, job, _, inputs in uploads
+    )
+    return actual == Counter(expected.items())
 
 
 def check_mixed_upload_indentation():
@@ -141,7 +152,7 @@ def check_mixed_upload_indentation():
             "files": "second.xml",
         },
     ]
-    actual_inputs = [inputs for _, _, inputs in parse_uploads(lines)]
+    actual_inputs = [inputs for _, _, _, inputs in parse_uploads(lines)]
     if actual_inputs != expected_inputs:
         return ["Codecov uploads with mixed indentation were parsed incorrectly"]
     return []
@@ -155,22 +166,17 @@ for workflow_path in workflow_paths:
     lines = workflow_path.read_text(encoding="utf-8").splitlines()
     uploads = parse_uploads(lines)
 
-    expected_count = expected_uploads.get(relative_path)
-    if expected_count is not None and len(uploads) != expected_count:
-        errors.append(
-            f"{relative_path}: expected {expected_count} Codecov uploads, "
-            f"found {len(uploads)}"
-        )
-    if expected_count is not None:
-        checked_expected_workflows.add(relative_path)
     expected_workflow_files = expected_files.get(relative_path)
     if uploads and expected_workflow_files is None:
         errors.append(
             f"{relative_path}: unexpected Codecov upload workflow"
         )
-        expected_workflow_files = []
+    elif expected_workflow_files is not None:
+        checked_expected_workflows.add(relative_path)
+        if not files_match(uploads, expected_workflow_files):
+            errors.append(f"{relative_path}: unexpected Codecov files inputs")
 
-    for upload_index, (line_number, version, inputs) in enumerate(uploads):
+    for line_number, _, version, inputs in uploads:
         version_match = version_pattern.match(version)
         if version_match is None or int(version_match.group("major")) < 5:
             errors.append(
@@ -178,17 +184,6 @@ for workflow_path in workflow_paths:
                 "uses the legacy uploader"
             )
 
-        if upload_index >= len(expected_workflow_files):
-            errors.append(
-                f"{relative_path}:{line_number}: unexpected Codecov upload"
-            )
-            continue
-        expected_file = expected_workflow_files[upload_index]
-        if inputs.get("files") != expected_file:
-            errors.append(
-                f"{relative_path}:{line_number}: expected files input "
-                f"{expected_file!r}, found {inputs.get('files')!r}"
-            )
         if inputs.get("token") != "${{ secrets.CODECOV_TOKEN }}":
             errors.append(
                 f"{relative_path}:{line_number}: Codecov upload must pass "
@@ -205,7 +200,7 @@ for workflow_path in workflow_paths:
                 "fail_ci_if_error: false"
             )
 
-for relative_path in expected_uploads.keys() - checked_expected_workflows:
+for relative_path in expected_files.keys() - checked_expected_workflows:
     errors.append(f"{relative_path}: expected workflow file is missing")
 
 if errors:

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-codecov-upload-config.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-codecov-upload-config.sh
@@ -32,6 +32,19 @@ expected_uploads = {
     ".github/workflows/pd-store-ci.yml": 3,
     ".github/workflows/server-ci.yml": 1,
 }
+expected_files = {
+    ".github/workflows/commons-ci.yml": [
+        "hugegraph-commons/target/jacoco.xml",
+    ],
+    ".github/workflows/pd-store-ci.yml": [
+        "${{ env.REPORT_FILE }}",
+        "${{ env.REPORT_FILE }}",
+        "${{ env.REPORT_DIR }}/*.xml",
+    ],
+    ".github/workflows/server-ci.yml": [
+        "${{ env.REPORT_DIR }}/*.xml",
+    ],
+}
 action_pattern = re.compile(
     r"^(?P<indent>\s*)(?P<dash>-\s+)?uses:\s*"
     r"codecov/codecov-action@(?P<version>\S+)\s*$"
@@ -150,8 +163,14 @@ for workflow_path in workflow_paths:
         )
     if expected_count is not None:
         checked_expected_workflows.add(relative_path)
+    expected_workflow_files = expected_files.get(relative_path)
+    if uploads and expected_workflow_files is None:
+        errors.append(
+            f"{relative_path}: unexpected Codecov upload workflow"
+        )
+        expected_workflow_files = []
 
-    for line_number, version, inputs in uploads:
+    for upload_index, (line_number, version, inputs) in enumerate(uploads):
         version_match = version_pattern.match(version)
         if version_match is None or int(version_match.group("major")) < 5:
             errors.append(
@@ -159,15 +178,31 @@ for workflow_path in workflow_paths:
                 "uses the legacy uploader"
             )
 
-        if not inputs.get("files"):
+        if upload_index >= len(expected_workflow_files):
             errors.append(
-                f"{relative_path}:{line_number}: Codecov upload must use "
-                "the files input"
+                f"{relative_path}:{line_number}: unexpected Codecov upload"
+            )
+            continue
+        expected_file = expected_workflow_files[upload_index]
+        if inputs.get("files") != expected_file:
+            errors.append(
+                f"{relative_path}:{line_number}: expected files input "
+                f"{expected_file!r}, found {inputs.get('files')!r}"
             )
         if inputs.get("token") != "${{ secrets.CODECOV_TOKEN }}":
             errors.append(
                 f"{relative_path}:{line_number}: Codecov upload must pass "
                 "secrets.CODECOV_TOKEN for trusted runs"
+            )
+        if inputs.get("disable_search") != "true":
+            errors.append(
+                f"{relative_path}:{line_number}: Codecov upload must set "
+                "disable_search: true"
+            )
+        if inputs.get("fail_ci_if_error") != "false":
+            errors.append(
+                f"{relative_path}:{line_number}: Codecov upload must keep "
+                "fail_ci_if_error: false"
             )
 
 for relative_path in expected_uploads.keys() - checked_expected_workflows:


### PR DESCRIPTION
## Purpose of the PR

- close #3168

HugeGraph still uses `codecov/codecov-action@v3` for Commons,
PD/Store/HStore, and Server coverage uploads. Fork pull requests cannot access
`CODECOV_TOKEN`, so v3 falls back to the legacy anonymous uploader. That
uploader shares a global rate limit: HTTP 429 failures were observed on #3167
and #3161, while the uploader still exited with status 0 and left Codecov with
only a subset of the expected reports.

This PR modernizes the upload boundary only. It does not change JaCoCo
collection, aggregation, coverage thresholds, or production code. The
PD/Store report aggregation work remains independent in #3160 and #3161.

## Main Changes

- Upgrade all five repository coverage uploads from
  `codecov/codecov-action@v3` to `@v5`.
- Pass the existing `CODECOV_TOKEN` for trusted push and same-repository runs.
  On fork pull requests the secret remains unavailable by design, and v5 uses
  its fork-aware tokenless upload path.
- Replace the deprecated `file` input with `files` in every upload step.
- Add a repository-wide configuration contract that rejects legacy Codecov
  actions, missing `files` inputs, missing trusted-run token inputs, removed
  expected uploads, and newly added legacy upload steps.
- Keep Codecov transport errors non-blocking in this PR; this change does not
  add `fail_ci_if_error: true`.

## Verifying these changes

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - `bash hugegraph-server/hugegraph-dist/src/assembly/travis/test-codecov-upload-config.sh`
    - Parse the three changed workflows with SnakeYAML 1.33.
    - `mvn -q apache-rat:check -N -ntp`
    - `mvn editorconfig:check -pl hugegraph-server/hugegraph-dist -am -ntp`
    - `git diff --check`
    - The contract failed against the pre-change v3 configuration and passed
      after all five upload steps were migrated.
    - Mutation checks verified that it rejects a legacy upload in a newly
      added workflow and does not mistake `env.token` for `with.token`.

The external upload result is intentionally left to this PR's GitHub Actions
run, which exercises the v5 fork-aware tokenless path that cannot be reproduced
as a local Codecov upload.

## Does this PR potentially affect the following parts?

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh))
- [x]  Modify configurations
- [ ]  The public API
- [x]  Other affects (Codecov coverage upload transport and authentication)
- [ ]  Nope

## Documentation Status

- [ ]  `Doc - TODO`
- [ ]  `Doc - Done`
- [x]  `Doc - No Need`
