### PR TITLE
chore(ci): group Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+
+updates:
+  - package-ecosystem: "maven"
+    directories:
+      - "/"
+      - "/hugegraph-*"
+      - "/hugegraph-*/*"
+      - "/install-dist"
+    schedule:
+      interval: "weekly"
+    # Keep version updates disabled while retaining security updates.
+    open-pull-requests-limit: 0
+    groups:
+      jackson-security:
+        applies-to: "security-updates"
+        patterns:
+          - "com.fasterxml.jackson*"
+      grpc-protobuf-security:
+        applies-to: "security-updates"
+        patterns:
+          - "io.grpc:*"
+          - "com.google.protobuf:*"
+      logging-security:
+        applies-to: "security-updates"
+        patterns:
+          - "org.apache.logging.log4j:*"
+          - "org.slf4j:*"
+          - "ch.qos.logback:*"
+      spring-security:
+        applies-to: "security-updates"
+        patterns:
+          - "org.springframework*"
+      apache-commons-security:
+        applies-to: "security-updates"
+        patterns:
+          - "org.apache.commons:*"
+          - "commons-*:*"
+      other-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
## Purpose of the PR

Dependabot currently opens separate Maven security update pull requests for
the same dependency in different HugeGraph modules. This leaves many small,
duplicate-looking `chore(deps)` pull requests for maintainers to triage and
runs the full CI matrix repeatedly.

**Before:** security updates are split by Maven manifest, while adding a
Dependabot configuration naively would also enable routine version updates.

**After:** Maven security updates are grouped by compatibility family across
the reactor, with routine version updates explicitly disabled. The behavior is
controlled entirely by `.github/dependabot.yml`; no repository Settings change
or additional permission is required.

## Main Changes

- Cover the root POM, every `hugegraph-*` parent and child module, and
  `install-dist` (38 Maven manifests in total).
- Group security updates into Jackson, gRPC/Protobuf, logging, Spring, Apache
  Commons, and catch-all families.
- Set `open-pull-requests-limit: 0` so the configuration does not introduce
  ordinary version-update pull requests.
- Leave CodeQL, dependency review, existing CI workflows, labels, assignees,
  reviewers, and repository Settings unchanged.

Dependabot security updates are already active for this repository, as shown by
the existing Dependabot security pull requests. Once this configuration reaches
the default branch, Dependabot can recalculate those updates into the configured
groups. This PR does not manually close any existing pull request.

## Verifying these changes

- [x] Validate `.github/dependabot.yml` against the Dependabot 2.0 JSON schema.
- [x] Parse the YAML and assert that all six groups apply only to
  `security-updates`.
- [x] Assert that `open-pull-requests-limit` is `0`, no `target-branch` is set,
  and the catch-all group is last.
- [x] Verify that the configured directory patterns cover all 38 Maven
  manifests in the current repository.
- [x] Run `git diff --check`.

## Does this PR potentially affect the following parts?

- [ ] Dependencies
- [x] Modify configurations
- [ ] The public API
- [x] Other affects (Dependabot security update pull-request grouping)
- [ ] Nope

## Documentation Status

- [ ] `Doc - TODO`
- [ ] `Doc - Done`
- [x] `Doc - No Need`
