### PR TITLE
perf(core): optimize queryVerticesByIds and queryEdgesByIds for one id

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/tx/GraphTransaction.java
@@ -775,6 +775,12 @@ public class GraphTransaction extends IndexableTransaction {
                                                   boolean checkMustExist, HugeType type) {
         Query.checkForceCapacity(vertexIds.length);
 
+        if (vertexIds.length == 1) {
+            // Fast path: skip the id list, map and mapper iterator for one id
+            return this.queryVertexById(vertexIds[0], adjacentVertex,
+                                        checkMustExist, type);
+        }
+
         // NOTE: allowed duplicated vertices if query by duplicated ids
         List<Id> ids = InsertionOrderUtil.newList();
         Map<Id, HugeVertex> vertices = new HashMap<>(vertexIds.length);
@@ -808,22 +814,67 @@ public class GraphTransaction extends IndexableTransaction {
         }
 
         return new MapperIterator<>(ids.iterator(), id -> {
-            HugeVertex vertex = vertices.get(id);
-            if (vertex == null) {
-                if (checkMustExist) {
-                    throw new NotFoundException(
-                            "Vertex '%s' does not exist", id);
-                } else if (adjacentVertex) {
-                    assert !checkMustExist;
-                    // Return undefined if adjacentVertex but !checkMustExist
-                    vertex = HugeVertex.undefined(this.graph(), id);
-                } else {
-                    // Return null
-                    assert vertex == null;
-                }
-            }
-            return vertex;
+            return this.resolveVertex(vertices.get(id), id,
+                                         adjacentVertex, checkMustExist);
         });
+    }
+
+    /**
+     * Query a single vertex by id, with the same semantics as the multi-id
+     * path of {@link #queryVerticesByIds(Object[], boolean, boolean, HugeType)}
+     * but without allocating the id list, the result map and the mapper
+     * iterator; only an {@link IdQuery.OneIdQuery} is created on a miss.
+     */
+    private Iterator<Vertex> queryVertexById(Object vertexId, boolean adjacentVertex,
+                                             boolean checkMustExist, HugeType type) {
+        Id id = HugeVertex.getIdValue(vertexId);
+        if (id == null) {
+            return QueryResults.emptyIterator();
+        }
+
+        HugeVertex vertex = null;
+        if (this.verticesInTxSize() > 0) {
+            if (this.removedVertices.containsKey(id)) {
+                // The record has been deleted
+                return QueryResults.emptyIterator();
+            }
+            vertex = this.addedVertices.get(id);
+            if (vertex == null) {
+                vertex = this.updatedVertices.get(id);
+            }
+            if (vertex != null && vertex.expired()) {
+                // Found from local tx but expired
+                return QueryResults.emptyIterator();
+            }
+        }
+
+        if (vertex == null) {
+            // Query from backend store
+            IdQuery query = new IdQuery.OneIdQuery(type, id);
+            vertex = QueryResults.one(this.queryVerticesFromBackend(query));
+        }
+
+        vertex = this.resolveVertex(vertex, id, adjacentVertex, checkMustExist);
+        if (vertex == null) {
+            return QueryResults.emptyIterator();
+        }
+        return QueryResults.iterator(vertex);
+    }
+
+    private HugeVertex resolveVertex(HugeVertex vertex, Id id,
+                                     boolean adjacentVertex, boolean checkMustExist) {
+        if (vertex != null) {
+            return vertex;
+        }
+        if (checkMustExist) {
+            throw new NotFoundException("Vertex '%s' does not exist", id);
+        }
+        if (adjacentVertex) {
+            // Return undefined if adjacentVertex but !checkMustExist
+            return HugeVertex.undefined(this.graph(), id);
+        }
+        // Return null to skip the vertex
+        return null;
     }
 
     public Iterator<Vertex> queryVertices() {
@@ -934,6 +985,11 @@ public class GraphTransaction extends IndexableTransaction {
                                              boolean verifyId) {
         Query.checkForceCapacity(edgeIds.length);
 
+        if (edgeIds.length == 1) {
+            // Fast path: skip the id list, map and mapper iterator for one id
+            return this.queryEdgeById(edgeIds[0], verifyId);
+        }
+
         // NOTE: allowed duplicated edges if query by duplicated ids
         List<Id> ids = InsertionOrderUtil.newList();
         Map<Id, HugeEdge> edges = new HashMap<>(edgeIds.length);
@@ -989,6 +1045,50 @@ public class GraphTransaction extends IndexableTransaction {
             Edge edge = edges.get(id);
             return edge;
         });
+    }
+
+    /**
+     * Query a single edge by id, with the same semantics as the multi-id
+     * path of {@link #queryEdgesByIds(Object[], boolean)} but without
+     * allocating the id list, the result map and the mapper iterator; only
+     * an {@link IdQuery.OneIdQuery} is created on a miss.
+     */
+    private Iterator<Edge> queryEdgeById(Object edgeId, boolean verifyId) {
+        EdgeId id = HugeEdge.getIdValue(edgeId, !verifyId);
+        if (id == null) {
+            return QueryResults.emptyIterator();
+        }
+        if (id.direction() == Directions.IN) {
+            id = id.switchDirection();
+        }
+
+        if (this.edgesInTxSize() > 0) {
+            if (this.removedEdges.containsKey(id)) {
+                // The record has been deleted
+                return QueryResults.emptyIterator();
+            }
+            HugeEdge edge = this.addedEdges.get(id);
+            if (edge == null) {
+                edge = this.updatedEdges.get(id);
+            }
+            if (edge != null) {
+                // Found from local tx
+                if (edge.expired()) {
+                    return QueryResults.emptyIterator();
+                }
+                return QueryResults.iterator(edge);
+            }
+        }
+
+        /*
+         * Query from backend store and return the results directly, just
+         * like the multi-id path does when there is no local edge.
+         */
+        IdQuery query = new IdQuery.OneIdQuery(HugeType.EDGE, id);
+        Iterator<HugeEdge> it = this.queryEdgesFromBackend(query);
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Iterator<Edge> r = (Iterator) it;
+        return r;
     }
 
     public Iterator<Edge> queryEdges() {

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/EdgeCoreTest.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
@@ -33,6 +34,7 @@ import java.util.function.Function;
 import org.apache.hugegraph.HugeException;
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.backend.BackendException;
+import org.apache.hugegraph.backend.id.EdgeId;
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.backend.page.PageInfo;
@@ -46,6 +48,7 @@ import org.apache.hugegraph.backend.tx.GraphTransaction;
 import org.apache.hugegraph.config.CoreOptions;
 import org.apache.hugegraph.exception.LimitExceedException;
 import org.apache.hugegraph.exception.NoIndexException;
+import org.apache.hugegraph.exception.NotFoundException;
 import org.apache.hugegraph.schema.SchemaManager;
 import org.apache.hugegraph.schema.Userdata;
 import org.apache.hugegraph.structure.HugeEdge;
@@ -2728,6 +2731,176 @@ public class EdgeCoreTest extends BaseCoreTest {
     }
 
     @Test
+    public void testQueryEdgesByIdsWithLocalAndDuplicateIds() {
+        HugeGraph graph = graph();
+        init18Edges();
+
+        Object id1 = graph.traversal().E().toList().get(0).id();
+        // Added but not committed
+        Vertex james = graph.addVertex(T.label, "author", "id", 3,
+                                       "name", "Dennis Ritchie", "age", 70,
+                                       "lived", "New York");
+        Vertex book = graph.addVertex(T.label, "book", "name", "c-book");
+        Edge local = james.addEdge("authored", book, "score", 5);
+        Object id2 = local.id();
+
+        List<Edge> edges = ImmutableList.copyOf(graph.edges(id2, id1, id2));
+        Assert.assertEquals(3, edges.size());
+        Assert.assertSame(local, edges.get(0));
+        Assert.assertEquals(id1, edges.get(1).id());
+        Assert.assertSame(local, edges.get(2));
+
+        graph.tx().rollback();
+    }
+
+    @Test
+    public void testQuerySingleEdgeByIdInLocalTx() {
+        HugeGraph graph = graph();
+        init18Edges();
+
+        // Added but not committed
+        Vertex james = graph.addVertex(T.label, "author", "id", 3,
+                                       "name", "Dennis Ritchie", "age", 70,
+                                       "lived", "New York");
+        Vertex book = graph.addVertex(T.label, "book", "name", "c-book");
+        Edge edge = james.addEdge("authored", book, "score", 5);
+        Object id = edge.id();
+
+        List<Edge> edges = ImmutableList.copyOf(graph.edges(id));
+        Assert.assertEquals(1, edges.size());
+        Assert.assertSame(edge, edges.get(0));
+        Assert.assertSame(edge, graph.edge(id));
+        graph.tx().commit();
+
+        // Updated but not committed
+        edge = graph.edge(id);
+        edge.property("score", 6);
+
+        edges = ImmutableList.copyOf(graph.edges(id));
+        Assert.assertEquals(1, edges.size());
+        Assert.assertSame(edge, edges.get(0));
+        Assert.assertEquals(6, (int) graph.edge(id).value("score"));
+        graph.tx().rollback();
+
+        Assert.assertEquals(5, (int) graph.edge(id).value("score"));
+    }
+
+    @Test
+    public void testQuerySingleEdgeByIdRemovedInLocalTx() {
+        HugeGraph graph = graph();
+        init18Edges();
+
+        Edge edge = graph.traversal().E().toList().get(0);
+        Object id = edge.id();
+        Assert.assertTrue(graph.edges(id).hasNext());
+
+        edge.remove();
+        Assert.assertFalse(graph.edges(id).hasNext());
+        Assert.assertThrows(NotFoundException.class, () -> {
+            graph.edge(id);
+        }, e -> {
+            Assert.assertContains("does not exist", e.getMessage());
+        });
+
+        graph.tx().rollback();
+        Assert.assertTrue(graph.edges(id).hasNext());
+        Assert.assertEquals(id, graph.edge(id).id());
+    }
+
+    @Test
+    public void testQuerySingleEdgeByIdNotFound() {
+        HugeGraph graph = graph();
+        init18Edges();
+
+        String id = graph.traversal().E().toList().get(0).id() + "-not-exist";
+        Assert.assertFalse(graph.edges(id).hasNext());
+        Assert.assertThrows(NotFoundException.class, () -> {
+            graph.edge(id);
+        }, e -> {
+            Assert.assertContains("does not exist", e.getMessage());
+        });
+    }
+
+    @Test
+    public void testQuerySingleEdgeByInvalidId() {
+        HugeGraph graph = graph();
+        init18Edges();
+
+        // Invalid id is skipped by edges() and rejected by edge()
+        Assert.assertFalse(graph.edges("invalid-edge-id").hasNext());
+        Assert.assertThrows(NotFoundException.class, () -> {
+            graph.edge("invalid-edge-id");
+        }, e -> {
+            Assert.assertContains("Edge id must be formatted", e.getMessage());
+        });
+
+        Assert.assertFalse(graph.edges((Object) null).hasNext());
+        Assert.assertThrows(NotFoundException.class, () -> {
+            graph.edge(null);
+        }, e -> {
+            Assert.assertContains("does not exist", e.getMessage());
+        });
+    }
+
+    @Test
+    public void testQuerySingleEdgeByIdWithInDirection() {
+        HugeGraph graph = graph();
+        init18Edges();
+
+        HugeEdge edge = (HugeEdge) graph.traversal().E().toList().get(0);
+        EdgeId inId = edge.idWithDirection().switchDirection();
+        Assert.assertEquals(Directions.IN, inId.direction());
+
+        List<Edge> edges = ImmutableList.copyOf(graph.edges(inId));
+        Assert.assertEquals(1, edges.size());
+        Assert.assertEquals(edge.id(), edges.get(0).id());
+        Assert.assertEquals(edge.id(), graph.edge(inId).id());
+
+        edges = ImmutableList.copyOf(graph.edges(inId.asString()));
+        Assert.assertEquals(1, edges.size());
+        Assert.assertEquals(edge.id(), edges.get(0).id());
+    }
+
+    @Test
+    public void testQuerySingleEdgeByIdExpiredInLocalTx() {
+        HugeGraph graph = graph();
+
+        Vertex baby = graph.addVertex(T.label, "person", "name", "Baby",
+                                      "age", 3, "city", "Beijing");
+        Vertex java = graph.addVertex(T.label, "book",
+                                      "name", "Java in action");
+        Edge edge = baby.addEdge("read", java, "place", "library of school",
+                                 "date", "2019-12-23 12:00:00");
+        Object id = edge.id();
+        graph.tx().commit();
+
+        edge = graph.edge(id);
+        Assert.assertTrue(graph.edges(id).hasNext());
+        graph.tx().rollback();
+
+        try {
+            Thread.sleep(3100L);
+        } catch (InterruptedException e) {
+            // Ignore
+        }
+
+        // Update the expired edge in a new tx (not committed)
+        edge.property("place", "home");
+        Map<Id, HugeEdge> updated = Whitebox.getInternalState(
+                params().graphTransaction(), "updatedEdges");
+        Assert.assertTrue(updated.containsKey(edge.id()));
+        Assert.assertTrue(((HugeEdge) edge).expired());
+
+        Assert.assertFalse(graph.edges(id).hasNext());
+        Assert.assertThrows(NotFoundException.class, () -> {
+            graph.edge(id);
+        }, e -> {
+            Assert.assertContains("does not exist", e.getMessage());
+        });
+        graph.tx().rollback();
+    }
+
+    @Test
     public void testQueryEdgesByIdNotFound() {
         HugeGraph graph = graph();
         init18Edges();
@@ -3320,6 +3493,49 @@ public class EdgeCoreTest extends BaseCoreTest {
             Whitebox.setInternalState(params().graphTransaction(),
                                       "checkAdjacentVertexExist", false);
         }
+    }
+
+    @Test
+    public void testQueryAdjacentVertexRemovedInLocalTx()
+            throws InterruptedException, ExecutionException {
+        HugeGraph graph = graph();
+
+        Vertex james = graph.addVertex(T.label, "author", "id", 1,
+                                       "name", "James Gosling", "age", 62,
+                                       "lived", "Canadian");
+        Vertex java = graph.addVertex(T.label, "book", "name", "java");
+        james.addEdge("authored", java, "score", 3);
+        graph.tx().commit();
+        params().graphEventHub().notify(Events.CACHE, "clear", null).get();
+
+        Edge edge = graph.traversal().V(james.id()).outE().next();
+        HugeVertex adjacent = (HugeVertex) edge.inVertex();
+        Assert.assertFalse(adjacent.isPropLoaded());
+        Assert.assertEquals("book", adjacent.label());
+
+        // Remove the adjacent vertex but don't commit
+        graph.vertex(java.id()).remove();
+        Assert.assertFalse(graph.vertices(java.id()).hasNext());
+        Assert.assertFalse(graph.adjacentVertex(java.id()).hasNext());
+        // Querying by one id must agree with querying by multiple ids
+        List<Vertex> vertices = ImmutableList.copyOf(
+                params().graphTransaction()
+                        .queryAdjacentVertices(java.id(), james.id()));
+        Assert.assertEquals(1, vertices.size());
+        Assert.assertEquals(james.id(), vertices.get(0).id());
+
+        /*
+         * Loading the adjacent vertex of an edge held before the removal
+         * must not turn it into an undefined vertex
+         */
+        adjacent.forceLoad();
+        Assert.assertFalse(adjacent.schemaLabel().undefined());
+        Assert.assertEquals("book", adjacent.label());
+
+        graph.tx().rollback();
+        Assert.assertTrue(graph.vertices(java.id()).hasNext());
+        Assert.assertEquals("book", graph.adjacentVertex(java.id())
+                                         .next().label());
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Random;
@@ -52,11 +53,13 @@ import org.apache.hugegraph.backend.tx.GraphTransaction;
 import org.apache.hugegraph.exception.LimitExceedException;
 import org.apache.hugegraph.exception.NoIndexException;
 import org.apache.hugegraph.exception.NotAllowException;
+import org.apache.hugegraph.exception.NotFoundException;
 import org.apache.hugegraph.schema.PropertyKey;
 import org.apache.hugegraph.schema.SchemaManager;
 import org.apache.hugegraph.schema.Userdata;
 import org.apache.hugegraph.schema.VertexLabel;
 import org.apache.hugegraph.structure.HugeElement;
+import org.apache.hugegraph.structure.HugeVertex;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.hugegraph.testutil.FakeObjects;
 import org.apache.hugegraph.testutil.Utils;
@@ -3186,6 +3189,174 @@ public class VertexCoreTest extends BaseCoreTest {
         Assert.assertTrue(graph.vertices(vertex1.id()).hasNext());
         Assert.assertTrue(graph.vertices(vertex2.id()).hasNext());
         Assert.assertTrue(graph.vertices(vertex1.id(), vertex2.id()).hasNext());
+    }
+
+    @Test
+    public void testQueryVerticesByNonConsecutiveDuplicateIds() {
+        HugeGraph graph = graph();
+        this.init10VerticesAndCommit();
+
+        List<Vertex> all = graph.traversal().V().toList();
+        Object id1 = all.get(0).id();
+        Object id2 = all.get(1).id();
+
+        List<Vertex> vertices = ImmutableList.copyOf(graph.vertices(id1, id2, id1));
+        Assert.assertEquals(3, vertices.size());
+        Assert.assertEquals(id1, vertices.get(0).id());
+        Assert.assertEquals(id2, vertices.get(1).id());
+        Assert.assertEquals(id1, vertices.get(2).id());
+    }
+
+    @Test
+    public void testQueryVerticesByIdsWithLocalAndDuplicateIds() {
+        HugeGraph graph = graph();
+        this.init10VerticesAndCommit();
+
+        Object id1 = graph.traversal().V().toList().get(0).id();
+        // Added but not committed
+        Vertex local = graph.addVertex(T.label, "author", "id", 3,
+                                       "name", "Dennis Ritchie", "age", 70,
+                                       "lived", "New York");
+        Object id2 = local.id();
+
+        List<Vertex> vertices = ImmutableList.copyOf(graph.vertices(id2, id1, id2));
+        Assert.assertEquals(3, vertices.size());
+        Assert.assertSame(local, vertices.get(0));
+        Assert.assertEquals(id1, vertices.get(1).id());
+        Assert.assertSame(local, vertices.get(2));
+
+        graph.tx().rollback();
+    }
+
+    @Test
+    public void testQuerySingleVertexByIdInLocalTx() {
+        HugeGraph graph = graph();
+        this.init10VerticesAndCommit();
+
+        // Added but not committed
+        Vertex vertex = graph.addVertex(T.label, "author", "id", 3,
+                                        "name", "Dennis Ritchie", "age", 70,
+                                        "lived", "New York");
+        Object id = vertex.id();
+
+        List<Vertex> vertices = ImmutableList.copyOf(graph.vertices(id));
+        Assert.assertEquals(1, vertices.size());
+        Assert.assertSame(vertex, vertices.get(0));
+        Assert.assertSame(vertex, graph.vertex(id));
+        Assert.assertSame(vertex, graph.adjacentVertex(id).next());
+        this.commitTx();
+
+        // Updated but not committed
+        vertex = graph.vertex(id);
+        vertex.property("age", 71);
+
+        vertices = ImmutableList.copyOf(graph.vertices(id));
+        Assert.assertEquals(1, vertices.size());
+        Assert.assertSame(vertex, vertices.get(0));
+        Assert.assertEquals(71, (int) graph.vertex(id).value("age"));
+        graph.tx().rollback();
+
+        Assert.assertEquals(70, (int) graph.vertex(id).value("age"));
+    }
+
+    @Test
+    public void testQuerySingleVertexByIdRemovedInLocalTx() {
+        HugeGraph graph = graph();
+        this.init10VerticesAndCommit();
+
+        Vertex vertex = graph.traversal().V().hasLabel("author")
+                             .has("id", 1).next();
+        Object id = vertex.id();
+        Assert.assertTrue(graph.vertices(id).hasNext());
+        Assert.assertTrue(graph.adjacentVertex(id).hasNext());
+
+        vertex.remove();
+        Assert.assertFalse(graph.vertices(id).hasNext());
+        // Removed vertex must not be reported as an undefined adjacent vertex
+        Assert.assertFalse(graph.adjacentVertex(id).hasNext());
+        Assert.assertThrows(NotFoundException.class, () -> {
+            graph.vertex(id);
+        }, e -> {
+            Assert.assertContains("does not exist", e.getMessage());
+        });
+
+        graph.tx().rollback();
+        Assert.assertTrue(graph.vertices(id).hasNext());
+        Assert.assertTrue(graph.adjacentVertex(id).hasNext());
+    }
+
+    @Test
+    public void testQuerySingleVertexByIdNotFound() {
+        HugeGraph graph = graph();
+        this.init10VerticesAndCommit();
+
+        Id id = SplicingIdGenerator.splicing("author", "not-exists-id");
+        Assert.assertFalse(graph.vertices(id).hasNext());
+        Assert.assertThrows(NotFoundException.class, () -> {
+            graph.vertex(id);
+        }, e -> {
+            Assert.assertContains("does not exist", e.getMessage());
+        });
+
+        // Adjacent vertex not found is returned as an undefined vertex
+        // (vertex.check_adjacent_vertex_exist=false, the default)
+        List<Vertex> vertices = ImmutableList.copyOf(graph.adjacentVertex(id));
+        Assert.assertEquals(1, vertices.size());
+        Assert.assertEquals(id, vertices.get(0).id());
+        Assert.assertEquals("~undefined", vertices.get(0).label());
+    }
+
+    @Test
+    public void testQuerySingleVertexByNullId() {
+        HugeGraph graph = graph();
+        this.init10VerticesAndCommit();
+
+        Assert.assertFalse(graph.vertices((Object) null).hasNext());
+        Assert.assertFalse(graph.adjacentVertex(null).hasNext());
+        Assert.assertThrows(NotFoundException.class, () -> {
+            graph.vertex(null);
+        }, e -> {
+            Assert.assertContains("does not exist", e.getMessage());
+        });
+
+        // Same as querying by multiple ids
+        Assert.assertFalse(graph.vertices(null, null).hasNext());
+    }
+
+    @Test
+    public void testQuerySingleVertexByIdExpiredInLocalTx() {
+        HugeGraph graph = graph();
+
+        Vertex vertex = graph.addVertex(T.label, "fan", "name", "Baby",
+                                        "age", 3, "city", "Beijing");
+        Object id = vertex.id();
+        this.commitTx();
+
+        vertex = graph.vertex(id);
+        Assert.assertTrue(graph.vertices(id).hasNext());
+        graph.tx().rollback();
+
+        try {
+            Thread.sleep(3100L);
+        } catch (InterruptedException e) {
+            // Ignore
+        }
+
+        // Update the expired vertex in a new tx (not committed)
+        vertex.property("age", 4);
+        Map<Id, HugeVertex> updated = Whitebox.getInternalState(
+                params().graphTransaction(), "updatedVertices");
+        Assert.assertTrue(updated.containsKey(vertex.id()));
+        Assert.assertTrue(((HugeVertex) vertex).expired());
+
+        Assert.assertFalse(graph.vertices(id).hasNext());
+        Assert.assertFalse(graph.adjacentVertex(id).hasNext());
+        Assert.assertThrows(NotFoundException.class, () -> {
+            graph.vertex(id);
+        }, e -> {
+            Assert.assertContains("does not exist", e.getMessage());
+        });
+        graph.tx().rollback();
     }
 
     @Test


### PR DESCRIPTION
## Purpose of the PR

Supersedes #2859, original work by @javeme (rebased onto current master, semantics fixed, tests and numbers added). The author has been inactive on it since 2025-09 and it was relabeled `help wanted`.

Querying a vertex or an edge by a single id is the hot path behind `graph.vertex(id)`, `graph.vertices(id)`, `graph.edge(id)`, `graph.adjacentVertex(id)` and the lazy adjacent-vertex loading in `HugeVertex.ensureFilledProperties()`. It currently goes through the general multi-id code in `GraphTransaction.queryVerticesByIds()` / `queryEdgesByIds()` and allocates an `IdQuery`, an id list, a `HashMap` and a `MapperIterator` on every call.

## Main Changes

- `GraphTransaction`: add a dedicated single-id path, `queryVertexById()` and `queryEdgeById()`, taken when exactly one id is passed. It does the three local-tx map lookups (only when the tx has changes) and, on a miss, a single `IdQuery.OneIdQuery` against the backend. The multi-id path is unchanged.
- The "vertex not found" handling (`NotFoundException` / undefined adjacent vertex / skip) is shared by both paths through `resolveVertex()`.

Differences from #2859, on purpose:

1. **Removed or expired records in the tx.** #2859 put the id into the result id list before checking the removed/expired maps, so `adjacentVertex(id)` for a vertex deleted in the current tx returned `HugeVertex.undefined(...)` instead of nothing. With the default `vertex.check_adjacent_vertex_exist=false` that silently relabels the other vertex of a held edge to `~undefined` and wipes its properties on the next property access. This PR keeps master's behaviour (nothing is returned), identical to the multi-id path. Covered by `testQueryAdjacentVertexRemovedInLocalTx`, `testQuerySingleVertexByIdRemovedInLocalTx` and the two `...ExpiredInLocalTx` tests.
2. **Single edge id from the backend.** #2859 routed it through `QueryResults.one()`, which throws if the backend yields two results, while master returns the backend iterator as is. Every backend answers an exact edge id with at most one column (memory `entry.contains(column)`, RocksDB `getById`, HStore `getById`) and `queryEdgesFromBackendInternal` already asserts that, so `one()` would most likely be safe, but there is no reason to change the contract in a perf PR: this PR returns the backend iterator directly, exactly like the multi-id path does for one id with no local hit. Note that this is guaranteed by construction (`queryEdgeById()` never calls `one()`), not by a test: no shipped backend can be made to yield two edges for one exact id, so a test would need a stubbed `queryEdgesFromBackend()`. For vertices the single-id backend path uses `QueryResults.one()`, which is what `CachedGraphTransaction.queryVerticesByIds()` already does today for every single-id query when the vertex cache is enabled (the default).
3. Not included: the 19 `@Watched` annotations, the `prefix = "tx"` to `"graph"` change on `prepareCommit()` (which would diverge from the 13 `prefix = "tx"` sites in `AbstractTransaction`), and the `optimizeQuery()` switch to `OneIdQuery` for primary-key lookups. They are unrelated to this optimization and can be separate PRs.
4. The two redundant `assert`s flagged by Copilot on #2859 are gone with the restructuring, and the boolean-flag control flow @imbajin commented on is replaced by early returns in the dedicated methods. I did not extract a shared `findVertexInLocalTx()` helper: the lookup has three outcomes (found, removed or expired, not tracked) so a helper would need a tri-state result or a second lookup, and folding the multi-id loops into it would touch code this PR otherwise leaves alone. If you would still like that, I am happy to do it here or as a follow-up.
5. The multi-id edge path keeps the `distinctIds` check from #2982: `[a, b, a]` still yields three edges (`testQueryEdgesByNonConsecutiveDuplicateIds`), and the same is now asserted for vertices and for mixed local/backend ids.

## Benchmark

JMH, memory backend with default cache settings, 1000 vertices in a chain, single thread, 1 fork, 3 warmup + 5 measurement iterations of 1 s, Apple M-series, OpenJDK 11.0.31. `clean` = no uncommitted change in the tx, `dirty` = one uncommitted vertex and edge in the tx. Lower is better (ns/op).

| Benchmark | tx | master (ns/op) | this PR (ns/op) | change |
|---|---|---:|---:|---:|
| `vertexByIdCommitted` (graph.vertices(id), cached vertex) | clean | 85.5 ± 0.9 | 29.0 ± 4.1 | -66% |
| `vertexByIdCommitted` (graph.vertices(id), cached vertex) | dirty | 83.5 ± 4.5 | 29.9 ± 8.6 | -64% |
| `vertexByIdStrict` (graph.vertex(id)) | clean | 84.2 ± 5.7 | 22.5 ± 0.7 | -73% |
| `vertexByIdStrict` (graph.vertex(id)) | dirty | 75.0 ± 0.2 | 25.7 ± 0.9 | -66% |
| `adjacentVertexById` (graph.adjacentVertex(id)) | clean | 97.1 ± 4.8 | 22.3 ± 0.5 | -77% |
| `adjacentVertexById` (graph.adjacentVertex(id)) | dirty | 80.7 ± 32.1 | 26.9 ± 0.3 | -67% |
| `vertexByIdMissing` (graph.vertices(id), id not found) | clean | 189.5 ± 8.4 | 116.8 ± 5.1 | -38% |
| `vertexByIdMissing` (graph.vertices(id), id not found) | dirty | 199.1 ± 25.3 | 110.6 ± 7.7 | -44% |
| `vertexByIdLocalTx` (graph.vertices(id), id added in tx (dirty only)) | dirty | 47.3 ± 2.3 | 31.3 ± 37.5 | -34% |
| `edgeByIdCommitted` (graph.edges(id), cached edge) | clean | 491.8 ± 15.1 | 459.0 ± 142.5 | -7% |
| `edgeByIdCommitted` (graph.edges(id), cached edge) | dirty | 549.0 ± 39.2 | 449.3 ± 27.8 | -18% |
| `edgeByIdLocalTx` (graph.edges(id), id added in tx (dirty only)) | dirty | 94.4 ± 7.4 | 19.2 ± 4.3 | -80% |
| `verticesByTwoIds` (graph.vertices(id1, id2), multi-id path, unchanged) | clean | 184.5 ± 8.6 | 176.9 ± 11.7 | -4% |
| `verticesByTwoIds` (graph.vertices(id1, id2), multi-id path, unchanged) | dirty | 189.5 ± 2.1 | 183.7 ± 20.4 | -3% |

The single-id vertex lookups drop from roughly 80 to 100 ns to 22 to 30 ns, mostly by not allocating an `IdQuery`, a list, a `HashMap` and a `MapperIterator` per call. A cached edge lookup is dominated by `EdgeId` parsing and the edge cache key, so it only gains 7 to 18 percent; the local-tx edge hit gains the most. The multi-id path is within noise, as expected.

The harness is `QueryByIdBenchmark` (not part of this PR, happy to add it under `hugegraph-test/src/test/java/org/apache/hugegraph/benchmark` if wanted).

## Verifying these changes

- [x] Need tests and can be verified as follows:
    - `VertexCoreTest`: `testQuerySingleVertexByIdInLocalTx` (added and updated), `testQuerySingleVertexByIdRemovedInLocalTx`, `testQuerySingleVertexByIdNotFound`, `testQuerySingleVertexByNullId`, `testQuerySingleVertexByIdExpiredInLocalTx`, `testQueryVerticesByNonConsecutiveDuplicateIds`, `testQueryVerticesByIdsWithLocalAndDuplicateIds`
    - `EdgeCoreTest`: `testQuerySingleEdgeByIdInLocalTx`, `testQuerySingleEdgeByIdRemovedInLocalTx`, `testQuerySingleEdgeByIdNotFound`, `testQuerySingleEdgeByInvalidId`, `testQuerySingleEdgeByIdWithInDirection`, `testQuerySingleEdgeByIdExpiredInLocalTx`, `testQueryEdgesByIdsWithLocalAndDuplicateIds`, `testQueryAdjacentVertexRemovedInLocalTx`
    - Ran locally on the memory backend (JDK 11): `mvn test -pl hugegraph-server/hugegraph-test -am -P core-test,memory`, `CoreTestSuite`: 819 run, 0 failures, 0 errors, 94 skipped (the usual "Not support paging" / hstore-only skips). `UnitTestSuite` was not run in full; `CachedGraphTransactionTest` (the cache override of the single-id backend query): 13 run, 0 failures. Checkstyle (`mvn validate`) passes with 0 violations.
    - Not run: RocksDB, HBase and HStore backends. The change is backend-neutral (it only reorders which maps are consulted before the same backend query), so CI coverage on those is what I rely on.

## Does this PR potentially affect the following parts?

- [x]  Nope

## Documentation Status

- [x]  `Doc - No Need`
