### PR TITLE
fix(server): reject vertex-property metadata during addV

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/HugePrimaryKeyStrategy.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/HugePrimaryKeyStrategy.java
@@ -30,6 +30,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AddPropertyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality;
 
 public class HugePrimaryKeyStrategy
@@ -76,7 +77,6 @@ public class HugePrimaryKeyStrategy
                 || propertyStep.getCardinality() == null) {
 
                 Object[] kvs = new Object[2];
-                List<Object> kvList = new LinkedList<>();
 
                 propertyStep.getParameters().getRaw().forEach((k, v) -> {
                     if (T.key.equals(k)) {
@@ -84,16 +84,11 @@ public class HugePrimaryKeyStrategy
                     } else if (T.value.equals(k)) {
                         kvs[1] = v.get(0);
                     } else {
-                        kvList.add(k.toString());
-                        kvList.add(v.get(0));
+                        throw VertexProperty.Exceptions.metaPropertiesNotSupported();
                     }
                 });
 
                 curAddStep.configure(kvs);
-
-                if (!kvList.isEmpty()) {
-                    curAddStep.configure(kvList.toArray(new Object[0]));
-                }
 
                 removeSteps.add(step);
             } else {

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/HugePrimaryKeyStrategy.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/HugePrimaryKeyStrategy.java
@@ -19,6 +19,7 @@ package org.apache.hugegraph.traversal.optimize;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -30,7 +31,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AddPropertyStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.structure.T;
-import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality;
 
 public class HugePrimaryKeyStrategy
@@ -77,20 +77,33 @@ public class HugePrimaryKeyStrategy
                 || propertyStep.getCardinality() == null) {
 
                 Object[] kvs = new Object[2];
+                boolean extraParams = false;
 
-                propertyStep.getParameters().getRaw().forEach((k, v) -> {
-                    if (T.key.equals(k)) {
-                        kvs[0] = v.get(0);
-                    } else if (T.value.equals(k)) {
-                        kvs[1] = v.get(0);
+                for (Map.Entry<Object, List<Object>> param :
+                     propertyStep.getParameters().getRaw().entrySet()) {
+                    Object paramKey = param.getKey();
+                    if (T.key.equals(paramKey)) {
+                        kvs[0] = param.getValue().get(0);
+                    } else if (T.value.equals(paramKey)) {
+                        kvs[1] = param.getValue().get(0);
                     } else {
-                        throw VertexProperty.Exceptions.metaPropertiesNotSupported();
+                        extraParams = true;
                     }
-                });
+                }
 
                 curAddStep.configure(kvs);
 
-                removeSteps.add(step);
+                if (extraParams) {
+                    /*
+                     * Rejecting here would run for every child traversal, so an
+                     * unreachable coalesce()/choose() branch would fail too. Leave
+                     * the step for HugeVertex.property() to reject when it really
+                     * runs, and stop folding across it.
+                     */
+                    curAddStep = null;
+                } else {
+                    removeSteps.add(step);
+                }
             } else {
                 curAddStep = null;
             }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CoreTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CoreTestSuite.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
         VertexCoreTest.class,
         EdgeCoreTest.class,
         CountStrategyCoreTest.class,
+        PrimaryKeyStrategyCoreTest.class,
         ParentAndSubEdgeCoreTest.class,
         PropertyCoreTest.VertexPropertyCoreTest.class,
         PropertyCoreTest.EdgePropertyCoreTest.class,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/PrimaryKeyStrategyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/PrimaryKeyStrategyCoreTest.java
@@ -20,7 +20,9 @@ package org.apache.hugegraph.core;
 import org.apache.hugegraph.schema.SchemaManager;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AddPropertyStep;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.junit.Test;
@@ -29,50 +31,128 @@ public class PrimaryKeyStrategyCoreTest extends BaseCoreTest {
 
     private static final String LABEL = "person";
 
+    private static final String META_PROPERTIES_ERROR =
+            VertexProperty.Exceptions.metaPropertiesNotSupported().getMessage();
+    private static final String USER_SUPPLIED_IDS_ERROR =
+            VertexProperty.Exceptions.userSuppliedIdsNotSupported().getMessage();
+
     private void initSchema() {
         SchemaManager schema = graph().schema();
         schema.propertyKey("name").asText().create();
         schema.propertyKey("country").asText().create();
-        schema.vertexLabel(LABEL)
-              .properties("name", "country")
-              .primaryKeys("name")
-              .nullableKeys("country")
-              .create();
+        schema.propertyKey("since").asText().create();
+        schema.vertexLabel(LABEL).properties("name", "country", "since")
+              .primaryKeys("name").nullableKeys("country", "since").create();
+    }
+
+    /**
+     * Applying the strategy must stay side effect free: the metadata-bearing step is left in the
+     * traversal so that HugeVertex.property() can reject it when the step really runs.
+     */
+    @Test
+    public void testKeepsMetaPropertyStepUnfolded() {
+        this.initSchema();
+
+        GraphTraversal<Vertex, Vertex> traversal = graph().traversal().addV(LABEL)
+                                                          .property("country", "cn", "since", "2024");
+        traversal.asAdmin().applyStrategies();
+
+        Assert.assertTrue(traversal.asAdmin().getSteps().stream()
+                                   .anyMatch(AddPropertyStep.class::isInstance));
+        Assert.assertEquals(0L, graph().traversal().V().hasLabel(LABEL).count().next());
     }
 
     @Test
     public void testStartStepRejectsMetaProperties() {
         this.initSchema();
-        GraphTraversal<?, Vertex> traversal = graph().traversal()
-                                                   .addV(LABEL)
-                                                   .property("name", "marko",
-                                                             "country", "cn");
-        this.assertMetaPropertiesRejected(traversal);
+
+        GraphTraversal<Vertex, Vertex> traversal = graph().traversal().addV(LABEL)
+                                                          .property("name", "marko")
+                                                          .property("country", "cn", "since", "2024");
+
+        this.assertRejectedWhenExecuted(traversal, META_PROPERTIES_ERROR);
     }
 
     @Test
     public void testMidTraversalStepRejectsMetaProperties() {
         this.initSchema();
-        GraphTraversal<?, Vertex> traversal = graph().traversal()
-                                                   .inject(1)
-                                                   .addV(LABEL)
-                                                   .property("name", "marko",
-                                                             "country", "cn");
-        this.assertMetaPropertiesRejected(traversal);
+
+        GraphTraversal<Integer, Vertex> traversal = graph().traversal().inject(1).addV(LABEL)
+                                                           .property("name", "marko")
+                                                           .property("country", "cn", "since", "2024");
+
+        this.assertRejectedWhenExecuted(traversal, META_PROPERTIES_ERROR);
+    }
+
+    /**
+     * The metadata-bearing step carries the primary key, so the strategy still has to fold
+     * T.key/T.value into addV(). Otherwise the vertex creation fails first with an
+     * IllegalArgumentException about the missing primary key, and the traversal never reaches the
+     * metadata validation this test is about.
+     */
+    @Test
+    public void testPrimaryKeyIsFoldedIntoAddVBeforeMetaPropertyCheck() {
+        this.initSchema();
+
+        GraphTraversal<Vertex, Vertex> traversal = graph().traversal().addV(LABEL)
+                                                          .property("name", "marko", "since", "2024");
+
+        this.assertRejectedWhenExecuted(traversal, META_PROPERTIES_ERROR);
+    }
+
+    @Test
+    public void testUserSuppliedVertexPropertyIdRejected() {
+        this.initSchema();
+
+        GraphTraversal<Vertex, Vertex> traversal = graph().traversal().addV(LABEL)
+                                                          .property("name", "marko", T.id, 1);
+
+        this.assertRejectedWhenExecuted(traversal, USER_SUPPLIED_IDS_ERROR);
+    }
+
+    /**
+     * TinkerPop applies strategies to coalesce() children before a branch is selected, so eager
+     * validation would fail this traversal even though unfold() answers it and the addV() fallback
+     * never runs.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUnreachableCoalesceBranchIsNotValidated() {
+        this.initSchema();
+        graph().addVertex(T.label, LABEL, "name", "marko");
+        commitTx();
+
+        GraphTraversal<Vertex, Vertex> traversal =
+                graph().traversal().V().hasLabel(LABEL).fold()
+                       .coalesce(__.unfold(),
+                                 __.addV(LABEL).property("name", "marko", "since", "2024"));
+
+        this.assertFallbackNotExecuted(traversal);
+    }
+
+    @Test
+    public void testUnreachableChooseBranchIsNotValidated() {
+        this.initSchema();
+        graph().addVertex(T.label, LABEL, "name", "marko");
+        commitTx();
+
+        GraphTraversal<Vertex, Vertex> traversal =
+                graph().traversal().V().hasLabel(LABEL).fold()
+                       .choose(__.unfold().count().is(0L),
+                               __.addV(LABEL).property("name", "marko", "since", "2024"),
+                               __.unfold());
+
+        this.assertFallbackNotExecuted(traversal);
     }
 
     @Test
     public void testFoldsSingleCardinalityProperties() {
         this.initSchema();
 
-        GraphTraversal<Vertex, Vertex> traversal = graph().traversal()
-                                                       .addV(LABEL)
-                                                       .property(
-                                                         VertexProperty.Cardinality.single,
-                                                         "name", "marko")
-                                                       .property(
-                                                         VertexProperty.Cardinality.single,
-                                                         "country", "cn");
+        GraphTraversal<Vertex, Vertex> traversal =
+                graph().traversal().addV(LABEL)
+                       .property(VertexProperty.Cardinality.single, "name", "marko")
+                       .property(VertexProperty.Cardinality.single, "country", "cn");
         traversal.asAdmin().applyStrategies();
         Assert.assertFalse(traversal.asAdmin().getSteps().stream()
                                     .anyMatch(AddPropertyStep.class::isInstance));
@@ -82,19 +162,24 @@ public class PrimaryKeyStrategyCoreTest extends BaseCoreTest {
 
         Assert.assertEquals("marko", vertex.value("name"));
         Assert.assertEquals("cn", vertex.value("country"));
-        Assert.assertEquals(1L, graph().traversal().V()
-                                           .hasLabel(LABEL).count().next());
+        Assert.assertEquals(1L, graph().traversal().V().hasLabel(LABEL).count().next());
     }
 
-    private void assertMetaPropertiesRejected(
-            GraphTraversal<?, Vertex> traversal) {
-        Assert.assertThrows(UnsupportedOperationException.class,
-                            traversal::next,
-                            e -> Assert.assertEquals(
-                                    "Properties on a vertex property is not " +
-                                    "supported",
-                                    e.getMessage()));
-        Assert.assertEquals(0L, graph().traversal().V()
-                                      .hasLabel(LABEL).count().next());
+    private void assertRejectedWhenExecuted(GraphTraversal<?, Vertex> traversal, String expectedError) {
+        Assert.assertThrows(UnsupportedOperationException.class, traversal::next,
+                            e -> Assert.assertEquals(expectedError, e.getMessage()));
+
+        // The addV() step already ran, so only the rollback guarantees that nothing survives
+        graph().tx().rollback();
+        Assert.assertEquals(0L, graph().traversal().V().hasLabel(LABEL).count().next());
+    }
+
+    private void assertFallbackNotExecuted(GraphTraversal<?, Vertex> traversal) {
+        Vertex vertex = traversal.next();
+        commitTx();
+
+        Assert.assertEquals("marko", vertex.value("name"));
+        Assert.assertFalse(vertex.property("since").isPresent());
+        Assert.assertEquals(1L, graph().traversal().V().hasLabel(LABEL).count().next());
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/PrimaryKeyStrategyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/PrimaryKeyStrategyCoreTest.java
@@ -20,96 +20,74 @@ package org.apache.hugegraph.core;
 import org.apache.hugegraph.schema.SchemaManager;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AddPropertyStep;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.junit.Test;
 
 public class PrimaryKeyStrategyCoreTest extends BaseCoreTest {
 
-    private static final String PRIMARY_LABEL = "primary";
-    private static final String AUTOMATIC_LABEL = "automatic";
+    private static final String LABEL = "person";
 
     private void initSchema() {
         SchemaManager schema = graph().schema();
         schema.propertyKey("name").asText().create();
         schema.propertyKey("country").asText().create();
-        schema.vertexLabel(PRIMARY_LABEL)
+        schema.vertexLabel(LABEL)
               .properties("name", "country")
               .primaryKeys("name")
               .nullableKeys("country")
               .create();
-        schema.vertexLabel(AUTOMATIC_LABEL)
-              .useAutomaticId()
-              .properties("name", "country")
-              .nullableKeys("name", "country")
-              .create();
     }
 
     @Test
-    public void testStartStepRejectsMetaPropertiesForPrimaryKeyLabel() {
-        this.assertMetaPropertiesRejected(PRIMARY_LABEL, false);
+    public void testStartStepRejectsMetaProperties() {
+        this.initSchema();
+        GraphTraversal<?, Vertex> traversal = graph().traversal()
+                                                   .addV(LABEL)
+                                                   .property("name", "marko",
+                                                             "country", "cn");
+        this.assertMetaPropertiesRejected(traversal);
     }
 
     @Test
-    public void testStartStepRejectsMetaPropertiesForAutomaticLabel() {
-        this.assertMetaPropertiesRejected(AUTOMATIC_LABEL, false);
+    public void testMidTraversalStepRejectsMetaProperties() {
+        this.initSchema();
+        GraphTraversal<?, Vertex> traversal = graph().traversal()
+                                                   .inject(1)
+                                                   .addV(LABEL)
+                                                   .property("name", "marko",
+                                                             "country", "cn");
+        this.assertMetaPropertiesRejected(traversal);
     }
 
     @Test
-    public void testMidTraversalStepRejectsMetaPropertiesForPrimaryKeyLabel() {
-        this.assertMetaPropertiesRejected(PRIMARY_LABEL, true);
-    }
-
-    @Test
-    public void testMidTraversalStepRejectsMetaPropertiesForAutomaticLabel() {
-        this.assertMetaPropertiesRejected(AUTOMATIC_LABEL, true);
-    }
-
-    @Test
-    public void testStartStepCreatesPrimaryKeyVertexWithOneProperty() {
+    public void testFoldsSingleCardinalityProperties() {
         this.initSchema();
 
-        Vertex vertex = graph().traversal()
-                               .addV(PRIMARY_LABEL)
-                               .property("name", "marko")
-                               .next();
-        commitTx();
+        GraphTraversal<Vertex, Vertex> traversal = graph().traversal()
+                                                       .addV(LABEL)
+                                                       .property(
+                                                         VertexProperty.Cardinality.single,
+                                                         "name", "marko")
+                                                       .property(
+                                                         VertexProperty.Cardinality.single,
+                                                         "country", "cn");
+        traversal.asAdmin().applyStrategies();
+        Assert.assertFalse(traversal.asAdmin().getSteps().stream()
+                                    .anyMatch(AddPropertyStep.class::isInstance));
 
-        Assert.assertEquals("marko", vertex.value("name"));
-        Assert.assertEquals(1L, graph().traversal().V()
-                                           .hasLabel(PRIMARY_LABEL)
-                                           .count().next());
-    }
-
-    @Test
-    public void testMidTraversalStepCreatesAutomaticVertexWithTwoProperties() {
-        this.initSchema();
-
-        Vertex vertex = graph().traversal()
-                               .inject(1)
-                               .addV(AUTOMATIC_LABEL)
-                               .property("name", "marko")
-                               .property("country", "cn")
-                               .next();
+        Vertex vertex = traversal.next();
         commitTx();
 
         Assert.assertEquals("marko", vertex.value("name"));
         Assert.assertEquals("cn", vertex.value("country"));
         Assert.assertEquals(1L, graph().traversal().V()
-                                           .hasLabel(AUTOMATIC_LABEL)
-                                           .count().next());
+                                           .hasLabel(LABEL).count().next());
     }
 
-    private void assertMetaPropertiesRejected(String label,
-                                              boolean midTraversal) {
-        this.initSchema();
-
-        GraphTraversal<?, Vertex> traversal = midTraversal ?
-                                               graph().traversal()
-                                                      .inject(1)
-                                                      .addV(label) :
-                                               graph().traversal().addV(label);
-        traversal.property("name", "marko", "country", "cn");
-
+    private void assertMetaPropertiesRejected(
+            GraphTraversal<?, Vertex> traversal) {
         Assert.assertThrows(UnsupportedOperationException.class,
                             traversal::next,
                             e -> Assert.assertEquals(
@@ -117,6 +95,6 @@ public class PrimaryKeyStrategyCoreTest extends BaseCoreTest {
                                     "supported",
                                     e.getMessage()));
         Assert.assertEquals(0L, graph().traversal().V()
-                                       .hasLabel(label).count().next());
+                                      .hasLabel(LABEL).count().next());
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/PrimaryKeyStrategyCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/PrimaryKeyStrategyCoreTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.core;
+
+import org.apache.hugegraph.schema.SchemaManager;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+
+public class PrimaryKeyStrategyCoreTest extends BaseCoreTest {
+
+    private static final String PRIMARY_LABEL = "primary";
+    private static final String AUTOMATIC_LABEL = "automatic";
+
+    private void initSchema() {
+        SchemaManager schema = graph().schema();
+        schema.propertyKey("name").asText().create();
+        schema.propertyKey("country").asText().create();
+        schema.vertexLabel(PRIMARY_LABEL)
+              .properties("name", "country")
+              .primaryKeys("name")
+              .nullableKeys("country")
+              .create();
+        schema.vertexLabel(AUTOMATIC_LABEL)
+              .useAutomaticId()
+              .properties("name", "country")
+              .nullableKeys("name", "country")
+              .create();
+    }
+
+    @Test
+    public void testStartStepRejectsMetaPropertiesForPrimaryKeyLabel() {
+        this.assertMetaPropertiesRejected(PRIMARY_LABEL, false);
+    }
+
+    @Test
+    public void testStartStepRejectsMetaPropertiesForAutomaticLabel() {
+        this.assertMetaPropertiesRejected(AUTOMATIC_LABEL, false);
+    }
+
+    @Test
+    public void testMidTraversalStepRejectsMetaPropertiesForPrimaryKeyLabel() {
+        this.assertMetaPropertiesRejected(PRIMARY_LABEL, true);
+    }
+
+    @Test
+    public void testMidTraversalStepRejectsMetaPropertiesForAutomaticLabel() {
+        this.assertMetaPropertiesRejected(AUTOMATIC_LABEL, true);
+    }
+
+    @Test
+    public void testStartStepCreatesPrimaryKeyVertexWithOneProperty() {
+        this.initSchema();
+
+        Vertex vertex = graph().traversal()
+                               .addV(PRIMARY_LABEL)
+                               .property("name", "marko")
+                               .next();
+        commitTx();
+
+        Assert.assertEquals("marko", vertex.value("name"));
+        Assert.assertEquals(1L, graph().traversal().V()
+                                           .hasLabel(PRIMARY_LABEL)
+                                           .count().next());
+    }
+
+    @Test
+    public void testMidTraversalStepCreatesAutomaticVertexWithTwoProperties() {
+        this.initSchema();
+
+        Vertex vertex = graph().traversal()
+                               .inject(1)
+                               .addV(AUTOMATIC_LABEL)
+                               .property("name", "marko")
+                               .property("country", "cn")
+                               .next();
+        commitTx();
+
+        Assert.assertEquals("marko", vertex.value("name"));
+        Assert.assertEquals("cn", vertex.value("country"));
+        Assert.assertEquals(1L, graph().traversal().V()
+                                           .hasLabel(AUTOMATIC_LABEL)
+                                           .count().next());
+    }
+
+    private void assertMetaPropertiesRejected(String label,
+                                              boolean midTraversal) {
+        this.initSchema();
+
+        GraphTraversal<?, Vertex> traversal = midTraversal ?
+                                               graph().traversal()
+                                                      .inject(1)
+                                                      .addV(label) :
+                                               graph().traversal().addV(label);
+        traversal.property("name", "marko", "country", "cn");
+
+        Assert.assertThrows(UnsupportedOperationException.class,
+                            traversal::next,
+                            e -> Assert.assertEquals(
+                                    "Properties on a vertex property is not " +
+                                    "supported",
+                                    e.getMessage()));
+        Assert.assertEquals(0L, graph().traversal().V()
+                                       .hasLabel(label).count().next());
+    }
+}


### PR DESCRIPTION
## Purpose of the PR

- Closes https://github.com/apache/hugegraph/issues/3165

`addV().property(key, value, metaKey, metaValue)` accepts unsupported
meta-properties instead of rejecting the traversal.

## Main Changes

Fold only `T.key` and `T.value` into `addV`, then leave metadata-bearing
`AddPropertyStep` instances in the traversal. If the branch executes,
`HugeVertex.property()` rejects the metadata. Unselected `coalesce()` and
`choose()` branches stay lazy, primary-key labels receive their key before
`addV` executes, and `T.id` keeps its specific unsupported-ID error.

## Verifying these changes

- [x] Need tests and can be verified as follows:

| Scenario | Result |
|---|---|
| Upstream behavior | Executed metadata traversals complete without the expected error |
| Final behavior | Executed branches reject at runtime; unreachable branches are unchanged |
| Memory-backed core suite | Passed on JDK 11 |

<details>
<summary>Raw logs</summary>

```text
$ RED=/tmp/hg-base
$ TEST=hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/PrimaryKeyStrategyCoreTest.java
$ git worktree add --detach "$RED" 90035b6e6339572cca2fe1bafd5242b1c300e0ea
$ git archive cf4f1598608b074579a778ca0a5e810ff29d6ebc "$TEST" | tar -x -C "$RED"
$ cd "$RED"
$ JAVA_HOME=$(/usr/libexec/java_home -v 11) mvn test \
    -pl hugegraph-server/hugegraph-test -am -P core-test,memory \
    -Dtest=PrimaryKeyStrategyCoreTest -DfailIfNoTests=false -Drevision=1.7.0
Tests run: 8, Failures: 5, Errors: 0, Skipped: 0
Start, mid-traversal, and primary-key cases:
  No exception was thrown(expected java.lang.UnsupportedOperationException)
Unfolded-step case: assertion failed
T.id: Bad exception type java.lang.IllegalArgumentException
BUILD FAILURE

$ GREEN=/tmp/hg-green
$ git worktree add --detach "$GREEN" cf4f1598608b074579a778ca0a5e810ff29d6ebc
$ cd "$GREEN"
$ JAVA_HOME=$(/usr/libexec/java_home -v 11) mvn test \
    -pl hugegraph-server/hugegraph-test -am -P core-test,memory \
    -Dtest=PrimaryKeyStrategyCoreTest -DfailIfNoTests=false -Drevision=1.7.0
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

</details>

## Does this PR potentially affect the following parts?

- [x] Nope

## Documentation Status

- [x] `Doc - No Need`
