### PR TITLE
fix(hstore): don't push sysprop-only range queries down to the store

### DIFF
--- a/hugegraph-server/hugegraph-hstore/src/main/java/org/apache/hugegraph/backend/store/hstore/HstoreTable.java
+++ b/hugegraph-server/hugegraph-hstore/src/main/java/org/apache/hugegraph/backend/store/hstore/HstoreTable.java
@@ -631,7 +631,6 @@ public class HstoreTable extends BackendTable<Session, BackendEntry> {
             type |= query.inclusiveEnd() ?
                     Session.SCAN_LTE_END : Session.SCAN_LT_END;
         }
-        ConditionQuery cq;
         Query origin = query.originQuery();
         byte[] position = null;
         byte[] ownerStart = this.ownerByQueryDelegate.apply(query.resultType(),
@@ -648,6 +647,7 @@ public class HstoreTable extends BackendTable<Session, BackendEntry> {
         if (query.paging() && !query.page().isEmpty()) {
             position = PageState.fromString(query.page()).position();
         }
+        byte[] queryBytes = null;
         if (origin instanceof ConditionQuery &&
             (query.resultType().isEdge() || query.resultType().isVertex())) {
             // Same guard as queryByPrefix(): only push the query down to the
@@ -656,13 +656,11 @@ public class HstoreTable extends BackendTable<Session, BackendEntry> {
             // label, sort values), which are already enforced by the key
             // range, and the store-side row decoder cannot parse the raw
             // property layout written by the server (see issue #3090).
-            cq = prepareConditionQuery((ConditionQuery) origin);
-            byte[] queryBytes = cq == null ? null : cq.bytes();
-            return session.scan(this.table(), ownerStart,
-                                ownerEnd, start, end, type, queryBytes, position);
+            ConditionQuery cq = prepareConditionQuery((ConditionQuery) origin);
+            queryBytes = cq == null ? null : cq.bytes();
         }
-        return session.scan(this.table(), ownerStart,
-                            ownerEnd, start, end, type, null, position);
+        return session.scan(this.table(), ownerStart, ownerEnd, start, end,
+                            type, queryBytes, position);
     }
 
     static boolean shouldUseOrderedRangeScan(IdRangeQuery query) {

--- a/hugegraph-server/hugegraph-hstore/src/main/java/org/apache/hugegraph/backend/store/hstore/HstoreTable.java
+++ b/hugegraph-server/hugegraph-hstore/src/main/java/org/apache/hugegraph/backend/store/hstore/HstoreTable.java
@@ -568,8 +568,11 @@ public class HstoreTable extends BackendTable<Session, BackendEntry> {
             }
         }
         if (newConditions.size() > 0) {
-            conditionQuery.resetConditions(newConditions);
-            return conditionQuery;
+            // NOTE: copy before reset, the origin query is still used by core
+            // for result filtering after the backend scan returns
+            ConditionQuery pushdown = conditionQuery.copy();
+            pushdown.resetConditions(newConditions);
+            return pushdown;
         } else {
             return null;
         }
@@ -594,8 +597,10 @@ public class HstoreTable extends BackendTable<Session, BackendEntry> {
             }
         }
         if (newConditions.size() > 0) {
-            conditionQuery.resetConditions(newConditions);
-            return conditionQuery;
+            // NOTE: copy before reset, see prepareConditionQuery()
+            ConditionQuery pushdown = conditionQuery.copy();
+            pushdown.resetConditions(newConditions);
+            return pushdown;
         } else {
             return null;
         }
@@ -642,16 +647,16 @@ public class HstoreTable extends BackendTable<Session, BackendEntry> {
         }
         if (origin instanceof ConditionQuery &&
             (query.resultType().isEdge() || query.resultType().isVertex())) {
-            cq = (ConditionQuery) query.originQuery();
-
-            // LOG.debug("query {} with ownerKeyFrom: {}, ownerKeyTo: {}, " +
-            //          "keyFrom: {}, keyTo: {}, " +
-            //          "scanType: {}, conditionQuery: {}",
-            //          this.table(), bytes2String(ownerStart),
-            //          bytes2String(ownerEnd), bytes2String(start),
-            //          bytes2String(end), type, cq.bytes());
+            // Same guard as queryByPrefix(): only push the query down to the
+            // store when user-prop conditions remain. A sort-key prefix/range
+            // query keeps sysprop conditions only (owner vertex, direction,
+            // label, sort values), which are already enforced by the key
+            // range, and the store-side row decoder cannot parse the raw
+            // property layout written by the server (see issue #3090).
+            cq = prepareConditionQuery((ConditionQuery) origin);
+            byte[] queryBytes = cq == null ? null : cq.bytes();
             return session.scan(this.table(), ownerStart,
-                                ownerEnd, start, end, type, cq.bytes(), position);
+                                ownerEnd, start, end, type, queryBytes, position);
         }
         return session.scan(this.table(), ownerStart,
                             ownerEnd, start, end, type, null, position);

--- a/hugegraph-server/hugegraph-hstore/src/main/java/org/apache/hugegraph/backend/store/hstore/HstoreTable.java
+++ b/hugegraph-server/hugegraph-hstore/src/main/java/org/apache/hugegraph/backend/store/hstore/HstoreTable.java
@@ -569,9 +569,11 @@ public class HstoreTable extends BackendTable<Session, BackendEntry> {
         }
         if (newConditions.size() > 0) {
             // NOTE: copy before reset, the origin query is still used by core
-            // for result filtering after the backend scan returns
+            // for result filtering after the backend scan returns; drop the
+            // back reference so the serialized payload stays flat
             ConditionQuery pushdown = conditionQuery.copy();
             pushdown.resetConditions(newConditions);
+            pushdown.setOriginQuery(null);
             return pushdown;
         } else {
             return null;
@@ -600,6 +602,7 @@ public class HstoreTable extends BackendTable<Session, BackendEntry> {
             // NOTE: copy before reset, see prepareConditionQuery()
             ConditionQuery pushdown = conditionQuery.copy();
             pushdown.resetConditions(newConditions);
+            pushdown.setOriginQuery(null);
             return pushdown;
         } else {
             return null;

--- a/hugegraph-server/hugegraph-hstore/src/test/java/org/apache/hugegraph/backend/store/hstore/HstoreTableTest.java
+++ b/hugegraph-server/hugegraph-hstore/src/test/java/org/apache/hugegraph/backend/store/hstore/HstoreTableTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.hugegraph.backend.store.hstore;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -29,6 +30,7 @@ import org.apache.hugegraph.backend.page.PageInfo;
 import org.apache.hugegraph.backend.page.PageState;
 import org.apache.hugegraph.backend.query.Condition;
 import org.apache.hugegraph.backend.query.ConditionQuery;
+import org.apache.hugegraph.backend.query.IdPrefixQuery;
 import org.apache.hugegraph.backend.query.IdRangeQuery;
 import org.apache.hugegraph.backend.query.Query;
 import org.apache.hugegraph.backend.store.BackendEntry;
@@ -177,6 +179,42 @@ public class HstoreTableTest {
         Assert.assertNull(pushed.originQuery());
     }
 
+    @Test
+    public void testPrefixListQueryPushesCopyAndKeepsOrigin() {
+        // prepareConditionQueryList() is reached from queryByPrefixList() and
+        // from the streaming query(Session, Iterator, String); one origin
+        // query is shared by every prefix query of the batch
+        ConditionQuery origin = new ConditionQuery(HugeType.EDGE);
+        origin.eq(HugeKeys.OWNER_VERTEX, IdGenerator.of("v1"));
+        origin.eq(HugeKeys.DIRECTION, Directions.OUT);
+        origin.eq(HugeKeys.LABEL, IdGenerator.of(1L));
+        origin.query(Condition.eq(IdGenerator.of(7L), 100));
+        int before = origin.conditions().size();
+        List<IdPrefixQuery> queries = Arrays.asList(
+                new IdPrefixQuery(origin, IdGenerator.of(keyBytes(1),
+                                                         IdType.STRING)),
+                new IdPrefixQuery(origin, IdGenerator.of(keyBytes(2),
+                                                         IdType.STRING)));
+
+        ScanRecordingSession session = new ScanRecordingSession();
+        List<BackendColumnIterator> iterators = this.newTestTable()
+                .queryByPrefixList(session, queries, "g+oe");
+
+        Assert.assertTrue(session.scanCalled);
+        Assert.assertEquals(2, session.lastOwnerKeys.size());
+        Assert.assertEquals(2, iterators.size());
+        Assert.assertNotNull(session.lastQueryBytes);
+        // the shared origin query keeps every condition, including the
+        // owner vertex that the pushed copy drops
+        Assert.assertEquals(before, origin.conditions().size());
+        Assert.assertNotNull(origin.condition(HugeKeys.OWNER_VERTEX));
+        ConditionQuery pushed = ConditionQuery.fromBytes(session.lastQueryBytes);
+        Assert.assertNull(pushed.condition(HugeKeys.OWNER_VERTEX));
+        Assert.assertNotNull(pushed.condition(HugeKeys.LABEL));
+        Assert.assertFalse(pushed.userpropConditions().isEmpty());
+        Assert.assertNull(pushed.originQuery());
+    }
+
     private HstoreTable newTestTable() {
         HstoreTable table = new HstoreTable("hugegraph", "g+oe");
         table.ownerByQueryDelegate = (type, id) -> new byte[]{0};
@@ -210,6 +248,7 @@ public class HstoreTableTest {
 
         private boolean scanCalled = false;
         private byte[] lastQueryBytes = null;
+        private List<HgOwnerKey> lastOwnerKeys = null;
 
         @Override
         public BackendColumnIterator scan(String table, byte[] ownerKeyFrom,
@@ -219,6 +258,21 @@ public class HstoreTableTest {
             this.scanCalled = true;
             this.lastQueryBytes = query;
             return new TestColumnIterator();
+        }
+
+        @Override
+        public List<BackendColumnIterator> scan(String table,
+                                                List<HgOwnerKey> keys,
+                                                int scanType, long limit,
+                                                byte[] query) {
+            this.scanCalled = true;
+            this.lastQueryBytes = query;
+            this.lastOwnerKeys = keys;
+            List<BackendColumnIterator> iterators = new ArrayList<>();
+            for (int i = 0; i < keys.size(); i++) {
+                iterators.add(new TestColumnIterator());
+            }
+            return iterators;
         }
 
         @Override
@@ -311,14 +365,6 @@ public class HstoreTableTest {
         @Override
         public BackendColumnIterator scan(String table, byte[] ownerKey,
                                           byte[] prefix) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public List<BackendColumnIterator> scan(String table,
-                                                List<HgOwnerKey> keys,
-                                                int scanType, long limit,
-                                                byte[] query) {
             throw new UnsupportedOperationException();
         }
 

--- a/hugegraph-server/hugegraph-hstore/src/test/java/org/apache/hugegraph/backend/store/hstore/HstoreTableTest.java
+++ b/hugegraph-server/hugegraph-hstore/src/test/java/org/apache/hugegraph/backend/store/hstore/HstoreTableTest.java
@@ -169,6 +169,12 @@ public class HstoreTableTest {
         // the pushed-down query is a copy: the origin query keeps all its
         // conditions for core-side filtering after the scan returns
         Assert.assertEquals(before, origin.conditions().size());
+        // pushed payload: user-prop condition survives, owner-vertex is
+        // dropped, and the back reference to the origin query is cleared
+        ConditionQuery pushed = ConditionQuery.fromBytes(session.lastQueryBytes);
+        Assert.assertNull(pushed.condition(HugeKeys.OWNER_VERTEX));
+        Assert.assertFalse(pushed.userpropConditions().isEmpty());
+        Assert.assertNull(pushed.originQuery());
     }
 
     private HstoreTable newTestTable() {

--- a/hugegraph-server/hugegraph-hstore/src/test/java/org/apache/hugegraph/backend/store/hstore/HstoreTableTest.java
+++ b/hugegraph-server/hugegraph-hstore/src/test/java/org/apache/hugegraph/backend/store/hstore/HstoreTableTest.java
@@ -18,21 +18,29 @@
 package org.apache.hugegraph.backend.store.hstore;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hugegraph.backend.id.Id.IdType;
 import org.apache.hugegraph.backend.id.IdGenerator;
 import org.apache.hugegraph.backend.page.PageInfo;
 import org.apache.hugegraph.backend.page.PageState;
+import org.apache.hugegraph.backend.query.Condition;
+import org.apache.hugegraph.backend.query.ConditionQuery;
 import org.apache.hugegraph.backend.query.IdRangeQuery;
 import org.apache.hugegraph.backend.query.Query;
 import org.apache.hugegraph.backend.store.BackendEntry;
 import org.apache.hugegraph.backend.store.BackendEntry.BackendColumn;
 import org.apache.hugegraph.backend.store.BackendEntry.BackendColumnIterator;
 import org.apache.hugegraph.backend.store.BackendEntryIterator;
+import org.apache.hugegraph.store.HgOwnerKey;
 import org.apache.hugegraph.store.client.util.HgStoreClientConst;
 import org.apache.hugegraph.type.HugeType;
+import org.apache.hugegraph.type.define.Directions;
+import org.apache.hugegraph.type.define.GraphMode;
+import org.apache.hugegraph.type.define.HugeKeys;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -124,6 +132,59 @@ public class HstoreTableTest {
         Assert.assertEquals(14L, HstoreTable.rangeScanBudget(query));
     }
 
+    @Test
+    public void testRangeQueryWithoutUserpropsDoesNotPushConditions() {
+        // Sort-key prefix/range queries keep sysprop conditions only (owner
+        // vertex, direction, label, sort values); those are enforced by the
+        // key range already and must not be pushed to the store, whose row
+        // decoder cannot parse the server's raw property layout (issue #3090)
+        ConditionQuery origin = new ConditionQuery(HugeType.EDGE);
+        origin.eq(HugeKeys.OWNER_VERTEX, IdGenerator.of("v1"));
+        origin.eq(HugeKeys.DIRECTION, Directions.OUT);
+        origin.eq(HugeKeys.LABEL, IdGenerator.of(1L));
+        origin.gte(HugeKeys.SORT_VALUES, "ETC!");
+        origin.lt(HugeKeys.SORT_VALUES, "ETC~");
+        int before = origin.conditions().size();
+
+        ScanRecordingSession session = new ScanRecordingSession();
+        this.newTestTable().queryByRange(session, edgeRangeQuery(origin));
+
+        Assert.assertTrue(session.scanCalled);
+        Assert.assertNull(session.lastQueryBytes);
+        Assert.assertEquals(before, origin.conditions().size());
+    }
+
+    @Test
+    public void testRangeQueryWithUserpropsPushesCopyAndKeepsOrigin() {
+        ConditionQuery origin = new ConditionQuery(HugeType.EDGE);
+        origin.eq(HugeKeys.OWNER_VERTEX, IdGenerator.of("v1"));
+        origin.query(Condition.eq(IdGenerator.of(7L), 100));
+        int before = origin.conditions().size();
+
+        ScanRecordingSession session = new ScanRecordingSession();
+        this.newTestTable().queryByRange(session, edgeRangeQuery(origin));
+
+        Assert.assertTrue(session.scanCalled);
+        Assert.assertNotNull(session.lastQueryBytes);
+        // the pushed-down query is a copy: the origin query keeps all its
+        // conditions for core-side filtering after the scan returns
+        Assert.assertEquals(before, origin.conditions().size());
+    }
+
+    private HstoreTable newTestTable() {
+        HstoreTable table = new HstoreTable("hugegraph", "g+oe");
+        table.ownerByQueryDelegate = (type, id) -> new byte[]{0};
+        return table;
+    }
+
+    private static IdRangeQuery edgeRangeQuery(ConditionQuery origin) {
+        return new IdRangeQuery(HugeType.EDGE_OUT, origin,
+                                IdGenerator.of(keyBytes(1), IdType.STRING),
+                                true,
+                                IdGenerator.of(keyBytes(9), IdType.STRING),
+                                false);
+    }
+
     private static IdRangeQuery rangeIndexQuery() {
         return new IdRangeQuery(HugeType.RANGE_INT_INDEX, null,
                                 IdGenerator.of(keyBytes(1), IdType.STRING),
@@ -137,6 +198,193 @@ public class HstoreTableTest {
         bytes[0] = HugeType.RANGE_INT_INDEX.code();
         bytes[8] = (byte) key;
         return bytes;
+    }
+
+    private static final class ScanRecordingSession extends HstoreSessions.Session {
+
+        private boolean scanCalled = false;
+        private byte[] lastQueryBytes = null;
+
+        @Override
+        public BackendColumnIterator scan(String table, byte[] ownerKeyFrom,
+                                          byte[] ownerKeyTo, byte[] keyFrom,
+                                          byte[] keyTo, int scanType,
+                                          byte[] query, byte[] position) {
+            this.scanCalled = true;
+            this.lastQueryBytes = query;
+            return new TestColumnIterator();
+        }
+
+        @Override
+        public void open() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public Object commit() {
+            return null;
+        }
+
+        @Override
+        public void rollback() {
+        }
+
+        @Override
+        public boolean hasChanges() {
+            return false;
+        }
+
+        @Override
+        public void createTable(String tableName) {
+        }
+
+        @Override
+        public void dropTable(String tableName) {
+        }
+
+        @Override
+        public boolean existsTable(String tableName) {
+            return true;
+        }
+
+        @Override
+        public void truncateTable(String tableName) {
+        }
+
+        @Override
+        public void deleteGraph() {
+        }
+
+        @Override
+        public Pair<byte[], byte[]> keyRange(String table) {
+            return null;
+        }
+
+        @Override
+        public void put(String table, byte[] ownerKey, byte[] key,
+                        byte[] value) {
+        }
+
+        @Override
+        public void increase(String table, byte[] ownerKey, byte[] key,
+                             byte[] value) {
+        }
+
+        @Override
+        public void delete(String table, byte[] ownerKey, byte[] key) {
+        }
+
+        @Override
+        public void deletePrefix(String table, byte[] ownerKey, byte[] key) {
+        }
+
+        @Override
+        public void deleteRange(String table, byte[] ownerKeyFrom,
+                                byte[] ownerKeyTo, byte[] keyFrom,
+                                byte[] keyTo) {
+        }
+
+        @Override
+        public byte[] get(String table, byte[] key) {
+            return new byte[0];
+        }
+
+        @Override
+        public byte[] get(String table, byte[] ownerKey, byte[] key) {
+            return new byte[0];
+        }
+
+        @Override
+        public BackendColumnIterator scan(String table) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BackendColumnIterator scan(String table, byte[] ownerKey,
+                                          byte[] prefix) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<BackendColumnIterator> scan(String table,
+                                                List<HgOwnerKey> keys,
+                                                int scanType, long limit,
+                                                byte[] query) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BackendEntry.BackendIterator<BackendColumnIterator> scan(
+                String table, Iterator<HgOwnerKey> keys, int scanType,
+                Query queryParam, byte[] query) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BackendColumnIterator scan(String table, byte[] ownerKeyFrom,
+                                          byte[] ownerKeyTo, byte[] keyFrom,
+                                          byte[] keyTo, int scanType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BackendColumnIterator scan(String table, byte[] ownerKeyFrom,
+                                          byte[] ownerKeyTo, byte[] keyFrom,
+                                          byte[] keyTo, int scanType,
+                                          byte[] query) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BackendColumnIterator scan(String table, int codeFrom,
+                                          int codeTo, int scanType,
+                                          byte[] query) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BackendColumnIterator scan(String table, int codeFrom,
+                                          int codeTo, int scanType,
+                                          byte[] query, byte[] position) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BackendColumnIterator scan(String table,
+                                          byte[] conditionQueryToByte) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BackendColumnIterator getWithBatch(String table,
+                                                  List<HgOwnerKey> keys) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void merge(String table, byte[] ownerKey, byte[] key,
+                          byte[] value) {
+        }
+
+        @Override
+        public void setMode(GraphMode mode) {
+        }
+
+        @Override
+        public void truncate() throws Exception {
+        }
+
+        @Override
+        public void beginTx() {
+        }
+
+        @Override
+        public int getActiveStoreSize() {
+            return 0;
+        }
     }
 
     private static final class TestColumnIterator


### PR DESCRIPTION
## Purpose of the PR

- part of #3090 (interim mitigation for the operator-sinking property codec mismatch)

On 1.7.x with HStore, every sort-key **prefix-equality or range** traversal fails, e.g. `g.V('a').outE('flow').has('asset','ETC')` → `Can't construct Cardinality from code 0`, or with a range on the second sort key → `Unsupported data type UNKNOWN`. Minimal REST+Gremlin reproducer: https://gist.github.com/SebastianGruza/616f81e915f00f08c4be3dc447ca77c7 (analysis in https://github.com/apache/hugegraph/issues/3090#issuecomment — see the September comment).

Root cause of the crash path: such a query reaches `HstoreTable.queryByRange()` with **sysprop conditions only** (owner vertex, direction, label, sort values) — all already enforced by the scan key range — but `queryByRange()` pushed the serialized `ConditionQuery` to the store **unconditionally**. The store-side row decoder then tries to parse property values it cannot parse (server writes raw values, store reader expects a self-describing `(cardinality<<6)|dataType` byte) and crashes on the first row in range.

## Main Changes

1. `queryByRange()` now applies the **same `prepareConditionQuery()` guard that `queryByPrefix()` already uses**: the query is pushed down only when user-prop conditions remain. No on-disk format change, no store-side change; the proper versioned sinking codec remains tracked in #3090.
2. Both `prepareConditionQuery()` / `prepareConditionQueryList()` now operate on a **copy** of the origin query instead of mutating it via `resetConditions()` — core still uses the origin query for its own result filtering after the scan returns.

## Verifying these changes

- New unit tests in `HstoreTableTest` (a scan-recording `Session` fake):
  - sysprop-only range query → `scan()` receives `null` query bytes, origin query untouched;
  - range query with a user-prop condition → query bytes are pushed **and** the origin query keeps all its conditions (guards the copy-not-mutate change).
- `mvn -pl hugegraph-server/hugegraph-hstore -am test -Dtest=HstoreTableTest`: 7/7 pass.
- **Live A/B on a local PD + HStore + Server cluster** (single-node, fresh graph, reproducer above):
  - `master` (98477f0): sort-key prefix query fails with `Can't construct Cardinality from code 0`, range on the second sort key fails with `Unsupported data type UNKNOWN` — exactly as reported;
  - this branch: **all 6 reproducer queries return correct results** (3 / 1 / 2 / 2 / 1 / 0 edges), verified with a jar swap in both directions on the same running cluster.

## Does this PR potentially affect the following parts?

- [ ] Nope
- [x] Logic (the HStore range-scan pushdown path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Note on `codecov/patch`:** the red patch check is an artifact — the surefire run of the `hugegraph-hstore` module is not part of the coverage upload, so the report shows 0 % for the changed lines although `HstoreTableTest` (8 tests) covers them. Scale measurement (13 sort-key shapes on 5 M edges, HStore vs RocksDB id sets): https://github.com/SebastianGruza/hugegraph-validation/tree/master/results/pr-3184-sortkeys
