### PR TITLE
perf(docker): reuse runtime layers and scope Maven builds

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -309,6 +309,56 @@ HUBBLE_PULL_POLICY=never \
 docker compose -f docker-compose-hstore.yml up -d --wait
 ```
 
+### Image build arguments and cache refresh
+
+The four Dockerfiles share an identical Maven build stage. `MAVEN_PROJECTS`
+selects the Server, PD, and Store distribution modules by default; `-am`
+includes their reactor dependencies. Override `MAVEN_PROJECTS` to replace the
+selection, and use `MAVEN_ARGS` for other Maven options. Custom selections must
+still produce all three distributions used by the shared build and archive
+cleanup.
+
+For example, include the PD CLI in addition to the three distributions. Run
+these build commands from the repository root, rather than the `docker/`
+directory used by the Compose commands above:
+
+```bash
+MAVEN_PROJECTS=':hugegraph-dist,:hg-pd-dist,:hg-store-dist,:hg-pd-cli' \
+docker buildx bake -f docker/bake.hcl
+```
+
+Runtime packages are installed before application artifacts are copied, so
+source changes reuse the package layer with either local or imported registry
+caches. Cached `apt-get update` and installation steps do not check for newer
+packages on each build. To refresh them, change `RUNTIME_DEPS_EPOCH` (default
+`1`) to a new value when package updates are required:
+
+```bash
+RUNTIME_DEPS_EPOCH=2 docker buildx bake -f docker/bake.hcl
+```
+
+Keep that value for subsequent builds to reuse the refreshed layer, and choose
+a new value for the next refresh. The argument is declared only in the runtime
+stage, immediately before the package installation step; overriding it does not
+invalidate the Maven build stage. Changes to the base image digest or package
+installation instructions also invalidate the package layer. Bake registry
+cache export remains opt-in through `EXPORT_CACHE=true`.
+
+Both arguments also work with direct Dockerfile builds, for example:
+
+```bash
+docker build -f hugegraph-server/Dockerfile \
+  --build-arg RUNTIME_DEPS_EPOCH=2 \
+  --build-arg MAVEN_PROJECTS=':hugegraph-dist,:hg-pd-dist,:hg-store-dist,:hg-pd-cli' \
+  -t hugegraph-standalone:local .
+```
+
+Build-context narrowing remains a follow-up: sources outside the default
+reactor selection still participate in `COPY . .` and can invalidate the Maven
+layer. Any future exclusions must preserve the `pom.xml` files referenced by
+the reactor and account for custom `MAVEN_PROJECTS` selections and assembly
+inputs; excluding entire module directories is not safe.
+
 ### Hubble configuration
 
 The three small files under `conf/hubble/` contain only topology-specific

--- a/docker/bake.hcl
+++ b/docker/bake.hcl
@@ -19,6 +19,14 @@ variable "MAVEN_ARGS" {
   default = ""
 }
 
+variable "MAVEN_PROJECTS" {
+  default = "hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist"
+}
+
+variable "RUNTIME_DEPS_EPOCH" {
+  default = "1"
+}
+
 variable "SOURCE_REVISION" {
   default = "local"
 }
@@ -38,8 +46,10 @@ variable "EXPORT_CACHE" {
 target "_common" {
   context = "."
   args = {
-    MAVEN_ARGS     = MAVEN_ARGS
-    SOURCE_REVISION = SOURCE_REVISION
+    MAVEN_ARGS         = MAVEN_ARGS
+    MAVEN_PROJECTS     = MAVEN_PROJECTS
+    RUNTIME_DEPS_EPOCH = RUNTIME_DEPS_EPOCH
+    SOURCE_REVISION    = SOURCE_REVISION
   }
   platforms = [
     "linux/amd64",

--- a/hugegraph-pd/Dockerfile
+++ b/hugegraph-pd/Dockerfile
@@ -28,14 +28,14 @@ ARG MAVEN_ARGS
 ARG SOURCE_REVISION=local
 
 RUN --mount=type=cache,id=hugegraph-maven-${SOURCE_REVISION},target=/root/.m2,sharing=locked \
-    mvn install $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
+    mvn install -pl hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist \
+        -am $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
     && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13
 FROM eclipse-temurin:11-jre-jammy
 
-COPY --from=build /pkg/hugegraph-pd/apache-hugegraph-pd-*/ /hugegraph-pd/
 LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"
 
 # TODO: use g1gc or zgc as default
@@ -57,6 +57,8 @@ RUN apt-get -q update \
        vim \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /pkg/hugegraph-pd/apache-hugegraph-pd-*/ /hugegraph-pd/
 
 # 2. Init docker script
 COPY hugegraph-pd/hg-pd-dist/docker/docker-entrypoint.sh .

--- a/hugegraph-pd/Dockerfile
+++ b/hugegraph-pd/Dockerfile
@@ -25,10 +25,11 @@ WORKDIR /pkg
 COPY . .
 
 ARG MAVEN_ARGS
+ARG MAVEN_PROJECTS="hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist"
 ARG SOURCE_REVISION=local
 
 RUN --mount=type=cache,id=hugegraph-maven-${SOURCE_REVISION},target=/root/.m2,sharing=locked \
-    mvn install -pl hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist \
+    mvn install -pl "$MAVEN_PROJECTS" \
         -am $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
     && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
 
@@ -49,6 +50,7 @@ WORKDIR /hugegraph-pd/
 # Note: lsof is gone because its only consumer was the dead check_port removed
 # from hg-pd-dist bin/util.sh.  PD runs no port preflight, so unlike the server
 # images this needs no socket-table tool in its place.
+ARG RUNTIME_DEPS_EPOCH=1
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends --no-install-suggests \
        dumb-init \

--- a/hugegraph-server/Dockerfile
+++ b/hugegraph-server/Dockerfile
@@ -28,14 +28,14 @@ ARG MAVEN_ARGS
 ARG SOURCE_REVISION=local
 
 RUN --mount=type=cache,id=hugegraph-maven-${SOURCE_REVISION},target=/root/.m2,sharing=locked \
-    mvn install $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
+    mvn install -pl hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist \
+        -am $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
     && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13
 FROM eclipse-temurin:11-jre-jammy
 
-COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-*/ /hugegraph-server/
 LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"
 
 # TODO: use g1gc or zgc as default
@@ -46,7 +46,7 @@ ENV JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:Max
 
 WORKDIR /hugegraph-server/
 
-# 1. Install runtime dependencies and configure server
+# 1. Install runtime dependencies
 # Note: iproute2 provides `ss`, which the bin/util.sh port preflight needs.  The
 # jammy base image ships neither ss nor netstat, so without it the preflight is
 # permanently inconclusive and a duplicate start is no longer caught.  It
@@ -59,8 +59,10 @@ RUN apt-get -q update \
        iproute2 \
        vim \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-*/ /hugegraph-server/
+RUN sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties
 
 # 2. Init docker script
 COPY hugegraph-server/hugegraph-dist/docker/scripts/remote-connect.groovy ./scripts

--- a/hugegraph-server/Dockerfile
+++ b/hugegraph-server/Dockerfile
@@ -25,10 +25,11 @@ WORKDIR /pkg
 COPY . .
 
 ARG MAVEN_ARGS
+ARG MAVEN_PROJECTS="hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist"
 ARG SOURCE_REVISION=local
 
 RUN --mount=type=cache,id=hugegraph-maven-${SOURCE_REVISION},target=/root/.m2,sharing=locked \
-    mvn install -pl hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist \
+    mvn install -pl "$MAVEN_PROJECTS" \
         -am $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
     && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
 
@@ -51,6 +52,7 @@ WORKDIR /hugegraph-server/
 # jammy base image ships neither ss nor netstat, so without it the preflight is
 # permanently inconclusive and a duplicate start is no longer caught.  It
 # replaces lsof, which no shipped script calls any more.
+ARG RUNTIME_DEPS_EPOCH=1
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends --no-install-suggests \
        dumb-init \

--- a/hugegraph-server/Dockerfile-hstore
+++ b/hugegraph-server/Dockerfile-hstore
@@ -28,17 +28,13 @@ ARG MAVEN_ARGS
 ARG SOURCE_REVISION=local
 
 RUN --mount=type=cache,id=hugegraph-maven-${SOURCE_REVISION},target=/root/.m2,sharing=locked \
-    mvn install $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
+    mvn install -pl hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist \
+        -am $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
     && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13
 FROM eclipse-temurin:11-jre-jammy
-
-COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-*/ /hugegraph-server/
-# remove hugegraph.properties and rename hstore.properties.template for default hstore backend
-RUN cd /hugegraph-server/conf/graphs \
-    && rm hugegraph.properties && mv hstore.properties.template hugegraph.properties
 
 LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"
 
@@ -48,7 +44,7 @@ ENV JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:Max
 
 WORKDIR /hugegraph-server/
 
-# 1. Install runtime dependencies and configure server
+# 1. Install runtime dependencies
 # Note: iproute2 provides `ss`, which the bin/util.sh port preflight needs.  The
 # jammy base image ships neither ss nor netstat, so without it the preflight is
 # permanently inconclusive and a duplicate start is no longer caught.  It
@@ -61,8 +57,13 @@ RUN apt-get -q update \
        iproute2 \
        vim \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-*/ /hugegraph-server/
+# remove hugegraph.properties and rename hstore.properties.template for default hstore backend
+RUN cd /hugegraph-server/conf/graphs \
+    && rm hugegraph.properties && mv hstore.properties.template hugegraph.properties
+RUN sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties
 
 # 2. Init docker script
 COPY hugegraph-server/hugegraph-dist/docker/scripts/remote-connect.groovy ./scripts

--- a/hugegraph-server/Dockerfile-hstore
+++ b/hugegraph-server/Dockerfile-hstore
@@ -25,10 +25,11 @@ WORKDIR /pkg
 COPY . .
 
 ARG MAVEN_ARGS
+ARG MAVEN_PROJECTS="hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist"
 ARG SOURCE_REVISION=local
 
 RUN --mount=type=cache,id=hugegraph-maven-${SOURCE_REVISION},target=/root/.m2,sharing=locked \
-    mvn install -pl hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist \
+    mvn install -pl "$MAVEN_PROJECTS" \
         -am $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
     && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
 
@@ -49,6 +50,7 @@ WORKDIR /hugegraph-server/
 # jammy base image ships neither ss nor netstat, so without it the preflight is
 # permanently inconclusive and a duplicate start is no longer caught.  It
 # replaces lsof, which no shipped script calls any more.
+ARG RUNTIME_DEPS_EPOCH=1
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends --no-install-suggests \
        dumb-init \
@@ -60,10 +62,11 @@ RUN apt-get -q update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /pkg/hugegraph-server/apache-hugegraph-server-*/ /hugegraph-server/
-# remove hugegraph.properties and rename hstore.properties.template for default hstore backend
+# Configure the default HStore backend and REST listen address
 RUN cd /hugegraph-server/conf/graphs \
-    && rm hugegraph.properties && mv hstore.properties.template hugegraph.properties
-RUN sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties
+    && rm hugegraph.properties && mv hstore.properties.template hugegraph.properties \
+    && cd /hugegraph-server \
+    && sed -i "s/^restserver.url.*$/restserver.url=http:\/\/0.0.0.0:8080/g" ./conf/rest-server.properties
 
 # 2. Init docker script
 COPY hugegraph-server/hugegraph-dist/docker/scripts/remote-connect.groovy ./scripts

--- a/hugegraph-store/Dockerfile
+++ b/hugegraph-store/Dockerfile
@@ -28,14 +28,14 @@ ARG MAVEN_ARGS
 ARG SOURCE_REVISION=local
 
 RUN --mount=type=cache,id=hugegraph-maven-${SOURCE_REVISION},target=/root/.m2,sharing=locked \
-    mvn install $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
+    mvn install -pl hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist \
+        -am $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
     && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
 
 # 2nd stage: runtime env
 # Note: ZGC (The Z Garbage Collector) is only supported on ARM-Mac with java > 13
 FROM eclipse-temurin:11-jre-jammy
 
-COPY --from=build /pkg/hugegraph-store/apache-hugegraph-store-*/ /hugegraph-store/
 LABEL maintainer="HugeGraph Docker Maintainers <dev@hugegraph.apache.org>"
 
 # TODO: use g1gc or zgc as default
@@ -57,6 +57,8 @@ RUN apt-get -q update \
        vim \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /pkg/hugegraph-store/apache-hugegraph-store-*/ /hugegraph-store/
 
 # 2. Init docker script
 COPY hugegraph-store/hg-store-dist/docker/docker-entrypoint.sh .

--- a/hugegraph-store/Dockerfile
+++ b/hugegraph-store/Dockerfile
@@ -25,10 +25,11 @@ WORKDIR /pkg
 COPY . .
 
 ARG MAVEN_ARGS
+ARG MAVEN_PROJECTS="hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist"
 ARG SOURCE_REVISION=local
 
 RUN --mount=type=cache,id=hugegraph-maven-${SOURCE_REVISION},target=/root/.m2,sharing=locked \
-    mvn install -pl hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist \
+    mvn install -pl "$MAVEN_PROJECTS" \
         -am $MAVEN_ARGS -e -B -ntp -Dmaven.test.skip=true -Dmaven.javadoc.skip=true \
     && rm ./hugegraph-server/*.tar.gz ./hugegraph-pd/*.tar.gz ./hugegraph-store/*.tar.gz
 
@@ -49,6 +50,7 @@ WORKDIR /hugegraph-store/
 # Note: lsof is gone because its only consumer was the dead check_port removed
 # from hg-store-dist bin/util.sh.  Store runs no port preflight, so unlike the
 # server images this needs no socket-table tool in its place.
+ARG RUNTIME_DEPS_EPOCH=1
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends --no-install-suggests \
        dumb-init \


### PR DESCRIPTION

### Visual summary

![Docker build cache and Maven scope](https://github.com/user-attachments/assets/91ceef9f-31b1-4b42-9411-70cca66e7058)
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/docs/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- close #3179 <!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #1024 -->

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

- Move runtime package installation before `COPY --from=build` in all four Dockerfiles, allowing dependency layers to survive application source changes.
- Keep configuration edits that depend on copied files after the corresponding `COPY`.
- Build the Server, PD, and Store distribution modules with `-pl` and `-am`, reducing the reactor from 38 to 27 modules while retaining required dependencies.
- Preserve existing runtime packages, configurable Maven arguments, and identical shared Maven build stages across all four Dockerfiles.

The existing single-job Bake flow and QEMU-based ARM64 build remain in place.

## Verifying these changes

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [x] Already covered by existing checks: multi-platform image inspection, Compose integration, Gremlin CRUD, and Standalone smoke tests.
- [x] Additional verification: before/after benchmarks and distribution/image content comparisons.

### Runtime dependency layer benchmark

Both variants used the same GitHub-hosted Ubuntu runner class and separate GHCR registry caches. After seeding each cache, identical configuration comments were added to trigger distribution changes and a full Maven rebuild.

| Scenario / metric | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Initial cache seed: image build | 552 s | 510 s | 42 s (7.6%) |
| Initial cache seed: complete job | 704 s | 669 s | 35 s (5.0%) |
| Source change: image build | 601 s | 461 s | 140 s (23.3%) |
| Source change: complete job | 755 s | 602 s | 153 s (20.3%) |

Before the change, the four ARM64 runtime package installation steps ran under QEMU and took 150.6–160.5 seconds each. After the change, all eight runtime dependency layers across amd64 and arm64 were restored from registry cache in 2.0–9.3 seconds per layer, without rerunning package installation.

Cache export was measured separately:

| Cache export vertex | Before | After |
| --- | ---: | ---: |
| Shared build cache | 205.2 s | 165.7 s |
| PD | 87.8 s | 5.5 s |
| Store | 56.1 s | 4.9 s |
| HStore Server | 83.3 s | 6.6 s |
| Standalone Server | 40.3 s | 8.1 s |

These BuildKit vertices overlap; their durations must not be added together or treated as independent end-to-end savings.

### Maven reactor benchmark

This separate experiment compared the full reactor with the scoped reactor using the same source and existing runtime layer optimization.

| Metric | Full reactor | Scoped reactor | Reduction |
| --- | ---: | ---: | ---: |
| Reactor modules | 38 | 27 | 11 modules |
| Maven-reported build time | 270 s | 176 s | 94 s (34.8%) |
| Distribution build, cache and local export | 424 s | 269 s | 155 s (36.6%) |
| Complete distribution job, including artifact upload | 492 s | 351 s | 141 s (28.7%) |

The distribution-job timings above are not complete image publication timings.

### Correctness checks

- Compared 391 distribution files, including permissions and normalized nested JAR contents.
- Compared all four images on both amd64 and arm64: 780 records per architecture covering application files, installed packages, and image configuration, with no missing, added, or changed records.
- JAR comparisons normalized ZIP timestamps, compression, entry order, and specified build-time metadata; this verifies effective content equivalence rather than byte-identical archives.
- The runtime-layer CI built and published all four images with both architectures, passing local platform inspection, Compose, Gremlin CRUD, Standalone smoke tests, and published manifest checks. Functional checks in this flow ran on amd64.
- A separate native ARM experiment passed functional checks on both architectures and final multi-platform publication. That experimental workflow is not included in this PR.

### Successful CI runs

| Validation | Result | CI run |
| --- | --- | --- |
| Runtime layer benchmark, multi-platform build and publication | All 4 jobs passed | [33950351952](https://github.com/lokidundun/incubator-hugegraph/actions/runs/33950351952) |
| Full/scoped distribution benchmark, content comparison, and native architecture validation | All 6 jobs passed | [33953324289](https://github.com/lokidundun/incubator-hugegraph/actions/runs/33953324289) |
| Full/scoped image content comparison on amd64 and arm64 | Both jobs passed | [33953049148](https://github.com/lokidundun/incubator-hugegraph/actions/runs/33953049148) |

These are fork validation runs for the implementation approach. The Maven experiments enabled the same module selection through `MAVEN_ARGS`; this PR places that selection directly in the Dockerfiles. These runs do not replace CI on the final PR commit.

Measurements are single-run observations using GHCR, not the official Docker Hub publication environment. Savings from separate experiments are not additive.

### Commands for local verification

Run from the repository root using Bash.

Build the selected distributions:

```bash
mvn install \
  -pl hugegraph-server/hugegraph-dist,hugegraph-pd/hg-pd-dist,hugegraph-store/hg-store-dist \
  -am -e -B -ntp \
  -Dmaven.test.skip=true \
  -Dmaven.javadoc.skip=true
```

Inspect the shared Bake configuration:

```bash
docker buildx bake -f docker/bake.hcl --print
```

Build all four images through the shared Bake flow:

```bash
docker buildx bake -f docker/bake.hcl --progress=plain
```

The default Bake targets include amd64 and arm64. Local multi-platform loading requires a compatible builder and the containerd image store; building ARM64 on an amd64 host also requires emulation.

Check a direct Dockerfile build:

```bash
docker buildx build \
  --platform linux/amd64 \
  -f hugegraph-server/Dockerfile \
  -t hugegraph-standalone:pr-check \
  --load .
```

The commands above are build checks; the linked CI runs provide the integration, content-comparison, and publication validation.

## Does this PR potentially affect the following parts?

- [ ] Dependencies
- [ ] Modify configurations
- [ ] The public API
- [x] Other affects: Docker build layer caching and Maven reactor selection.
- [ ] Nope

## Documentation Status

- [ ] `Doc - TODO`
- [ ] `Doc - Done`
- [x] `Doc - No Need`
