### PR TITLE
doc: require a paired hugegraph-doc PR for feature and config changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -62,6 +62,6 @@ For example:
 
 <!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->
 
-- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
+- [ ]  `Doc - TODO` <!-- Your PR changes impact docs. Link the hugegraph-doc PR or a tracking issue here, docs are not merged later from memory -->
 - [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
 - [ ]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -125,6 +125,12 @@ Note that since GitHub requires submitting code through `username + token` (inst
 
 Go to the web page of GitHub fork repo, there would be a chance to create a Pull Request after pushing to a new branch, click the button "Compare & pull request" to do it. Then edit the description for proposed changes, which can just be copied from the commit message.
 
+If the change touches a feature, a configuration item or a `Dockerfile`, open the matching
+documentation PR in [hugegraph-doc](https://github.com/apache/hugegraph-doc) at the same time
+and link the two together. Both should merge together. Documentation that trails the code
+goes stale quietly, and the gap is only found when a user or a search tool reads the wrong
+thing.
+
 Note: please make sure the email address you used to submit the code is bound to the GitHub account. For how to bind the email address, please refer to https://github.com/settings/emails:
 <img width="1280" alt="image" src="https://user-images.githubusercontent.com/9625821/163522445-2a50a72a-dea2-434f-9868-3a0d40d0d037.png">
 


### PR DESCRIPTION
## Purpose of the PR

Draft for discussion, companion to https://github.com/apache/hugegraph/pull/3197.

The PR template already has a `Documentation Status` section, so the intent is there. The
problem is the first option:

```
- [ ] `Doc - TODO`  <!-- Your PR changes impact docs and you will update later -->
```

"You will update later" is a promise with nothing attached to it. No link, no issue, no
follow-up, so once the code PR merges the box is the only record that documentation was
owed, and it stops being visible to anyone. The result is documentation that describes an
older version of the code, which readers and search tools then pick up as current.

`CONTRIBUTING.md` does not mention documentation at all in the section on opening a PR,
which is the point where a contributor decides whether to write any.

## Main Changes

- `.github/PULL_REQUEST_TEMPLATE.md`: `Doc - TODO` now asks for a link, either the
  hugegraph-doc PR or a tracking issue. Same three options, same structure, one comment
  reworded.
- `docs/CONTRIBUTING.md`: one paragraph in section 4, saying that a change to a feature, a
  configuration item or a `Dockerfile` opens the matching hugegraph-doc PR at the same
  time, and that the two merge together.

7 lines added, 1 reworded.

Two open points for review:

1. Should `Doc - TODO` require a link, or be removed entirely so the choice is `Done` or
   `No Need`? Requiring a link is the softer option and is what this PR does.
2. `CONTRIBUTING.md` says the website copy at
   https://hugegraph.apache.org/docs/contribution-guidelines/ is authoritative. If this
   lands, the same paragraph needs a matching hugegraph-doc PR, which is the rule applying
   to itself.

## Verifying these changes

- [x] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [ ] Need tests and can be verified as follows:
    - xxx

## Does this PR potentially affect the following parts?

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh))
- [ ]  Modify configurations
- [ ]  The public API
- [x]  Other affects (typed here)
    - Changes the PR template every contributor sees, and the contribution guide.
- [ ]  Nope

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x]  `Doc - TODO` <!-- website contribution-guidelines page needs the same paragraph, see point 2 above -->
- [ ]  `Doc - Done`
- [ ]  `Doc - No Need`
