### PR TITLE
fix(store-client): enhance thread interrupts in NodeTxExecutor

### DIFF
--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutor.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutor.java
@@ -22,13 +22,18 @@ import static org.apache.hugegraph.store.client.util.HgStoreClientConst.NODE_MAX
 import static org.apache.hugegraph.store.client.util.HgStoreClientConst.TX_SESSIONS_MAP_CAPACITY;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
@@ -131,35 +136,7 @@ final class NodeTxExecutor {
                 if (!allSuccess.get()) {
                     throw HgStoreClientException.of(msg);
                 }
-                AtomicReference<Throwable> throwable = new AtomicReference<>();
-                Collection<HgStoreSession> sessions = this.sessions.values();
-                sessions.parallelStream().forEach(e -> {
-                    if (e.isTx()) {
-                        try {
-                            e.commit();
-                        } catch (Throwable t) {
-                            throwable.compareAndSet(null, t);
-                            allSuccess.set(false);
-                        }
-                    }
-                });
-                if (!allSuccess.get()) {
-                    if (isTx) {
-                        try {
-                            sessions.stream().forEach(HgStoreSession::rollback);
-                        } catch (Exception e) {
-
-                        }
-                    }
-                    Throwable cause = throwable.get();
-                    if (cause.getCause() != null) {
-                        cause = cause.getCause();
-                    }
-                    if (cause instanceof HgStoreClientException) {
-                        throw (HgStoreClientException) cause;
-                    }
-                    throw HgStoreClientException.of(cause);
-                }
+                this.commitSessions(this.sessions.values());
                 return true;
             });
 
@@ -233,6 +210,52 @@ final class NodeTxExecutor {
     //        }
     //    }
     // };
+
+    /**
+     * Commit every tx session in parallel. When at least one commit fails, roll back (in tx
+     * mode) and throw one exception that carries ALL failures: the first one as the cause, the
+     * others as suppressed. The retry loop looks at all of them, so whether a commit is retried
+     * no longer depends on which partition happened to fail first.
+     */
+    void commitSessions(Collection<HgStoreSession> sessions) {
+        Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
+        sessions.parallelStream().forEach(e -> {
+            if (e.isTx()) {
+                try {
+                    e.commit();
+                } catch (Throwable t) {
+                    failures.add(t);
+                }
+            }
+        });
+        if (failures.isEmpty()) {
+            return;
+        }
+        if (isTx) {
+            try {
+                sessions.stream().forEach(HgStoreSession::rollback);
+            } catch (Exception e) {
+                // keep the commit failure as the reported one
+            }
+        }
+        throw aggregate(failures);
+    }
+
+    static HgStoreClientException aggregate(Collection<Throwable> failures) {
+        Iterator<Throwable> it = failures.iterator();
+        Throwable first = it.next();
+        Throwable cause = first.getCause() != null ? first.getCause() : first;
+        HgStoreClientException result = cause instanceof HgStoreClientException ?
+                                        (HgStoreClientException) cause :
+                                        HgStoreClientException.of(cause);
+        while (it.hasNext()) {
+            Throwable other = it.next();
+            if (other != result && other != cause) {
+                result.addSuppressed(other);
+            }
+        }
+        return result;
+    }
 
     private boolean doAction(HgTriple<String, HgOwnerKey, Object> nodeParams,
                              Function<NodeTkv, Boolean> action) {
@@ -389,17 +412,17 @@ final class NodeTxExecutor {
                                     try {
                                         buffer = supplier.get();
                                     } catch (Throwable t) {
-                                        if (i + 1 > NODE_MAX_RETRYING_TIMES) {
-                                            log.error(maxTryMsg, t);
-                                            throw HgStoreClientException.of(
-                                                    t.getMessage(), t);
-                                        }
                                         if (!isRetryable(t)) {
                                             // A deadline or a cancellation will not
                                             // get better by waiting the full deadline
                                             // again; fail fast and let the caller decide.
                                             log.warn("Not retrying after: {}",
-                                                     t.getMessage());
+                                                     t.getMessage(), t);
+                                            throw HgStoreClientException.of(
+                                                    t.getMessage(), t);
+                                        }
+                                        if (i + 1 > NODE_MAX_RETRYING_TIMES) {
+                                            log.error(maxTryMsg, t);
                                             throw HgStoreClientException.of(
                                                     t.getMessage(), t);
                                         }
@@ -428,11 +451,16 @@ final class NodeTxExecutor {
     /**
      * Retry only failures that a fresh attempt can plausibly fix (a transport error, a
      * leader change). A DEADLINE_EXCEEDED would wait the full deadline again, a CANCELLED
-     * means the caller's thread was interrupted; neither is retried.
+     * means the caller's thread was interrupted; neither is retried, also when it is one of
+     * several failures of a parallel commit.
      */
     static boolean isRetryable(Throwable t) {
+        return isRetryable(t, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    private static boolean isRetryable(Throwable t, Set<Throwable> seen) {
         Throwable c = t;
-        while (c != null) {
+        while (c != null && seen.add(c)) {
             if (c instanceof InterruptedException) {
                 return false;
             }
@@ -442,8 +470,12 @@ final class NodeTxExecutor {
                     return false;
                 }
             }
-            if (c.getCause() == c) {
-                break;
+            // A parallel commit reports the other partitions' failures as suppressed;
+            // one non-retryable failure among them makes the whole attempt non-retryable.
+            for (Throwable suppressed : c.getSuppressed()) {
+                if (!isRetryable(suppressed, seen)) {
+                    return false;
+                }
             }
             c = c.getCause();
         }

--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutor.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutor.java
@@ -406,8 +406,12 @@ final class NodeTxExecutor {
                                         // The caller (e.g. a REST worker hitting
                                         // restserver.request_timeout) gave up: stop
                                         // retrying instead of holding its thread.
+                                        // InterruptedException as the root cause: the
+                                        // server's task cancel path recognises it
+                                        // (HugeException.isInterrupted()).
                                         throw HgStoreClientException.of(
-                                                "Interrupted before retry " + i);
+                                                "Interrupted before retry " + i,
+                                                new InterruptedException());
                                     }
                                     T buffer = null;
                                     try {
@@ -453,9 +457,10 @@ final class NodeTxExecutor {
                                             Thread.sleep(sleepTime * 1000L);
                                         } catch (InterruptedException e) {
                                             Thread.currentThread().interrupt();
+                                            e.addSuppressed(t);
                                             throw HgStoreClientException.of(
                                                     "Interrupted while waiting to retry: " +
-                                                    t.getMessage(), t);
+                                                    t.getMessage(), e);
                                         }
                                     }
                                     return buffer;

--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutor.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutor.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
@@ -65,8 +64,6 @@ final class NodeTxExecutor {
     private static final String maxTryMsg =
             "the number of retries reached the upper limit : " + NODE_MAX_RETRYING_TIMES +
             ",caused by:";
-    private static final String msg =
-            "Not all tx-data delivered to real-node-session successfully.";
 
     static {
         System.setProperty("java.util.concurrent.ForkJoinPool.common.parallelism",
@@ -128,13 +125,9 @@ final class NodeTxExecutor {
                 if (this.entries.isEmpty()) {
                     return true;
                 }
-                AtomicBoolean allSuccess = new AtomicBoolean(true);
                 for (HgPair<HgTriple<String, HgOwnerKey, Object>, Function<NodeTkv, Boolean>> e :
                         this.entries) {
                     doAction(e.getKey(), e.getValue());
-                }
-                if (!allSuccess.get()) {
-                    throw HgStoreClientException.of(msg);
                 }
                 this.commitSessions(this.sessions.values());
                 return true;
@@ -418,6 +411,11 @@ final class NodeTxExecutor {
                                         buffer = supplier.get();
                                     } catch (Throwable t) {
                                         Failure failure = classify(t);
+                                        if (failure != Failure.DEADLINE) {
+                                            // a different failure in between means the
+                                            // next deadline is not "in a row" again
+                                            deadlineRetried[0] = false;
+                                        }
                                         if (failure == Failure.FATAL) {
                                             // The caller's thread was interrupted or the
                                             // call was cancelled: fail fast.

--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutor.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutor.java
@@ -398,6 +398,7 @@ final class NodeTxExecutor {
     }
 
     <T> Optional<T> retryingInvoke(Supplier<T> supplier) {
+        boolean[] deadlineRetried = {false};
         return IntStream.rangeClosed(0, NODE_MAX_RETRYING_TIMES).boxed()
                         .map(
                                 i -> {
@@ -412,14 +413,31 @@ final class NodeTxExecutor {
                                     try {
                                         buffer = supplier.get();
                                     } catch (Throwable t) {
-                                        if (!isRetryable(t)) {
-                                            // A deadline or a cancellation will not
-                                            // get better by waiting the full deadline
-                                            // again; fail fast and let the caller decide.
+                                        Failure failure = classify(t);
+                                        if (failure == Failure.FATAL) {
+                                            // The caller's thread was interrupted or the
+                                            // call was cancelled: fail fast.
                                             log.warn("Not retrying after: {}",
                                                      t.getMessage(), t);
                                             throw HgStoreClientException.of(
                                                     t.getMessage(), t);
+                                        }
+                                        if (failure == Failure.DEADLINE) {
+                                            // One retry: the NOT_WORK notice sent for the
+                                            // failed RPC reloads the partition leaders, so
+                                            // the next attempt can reach a new leader. A
+                                            // second deadline in a row would only wait the
+                                            // full deadline again on the same stalled store.
+                                            if (deadlineRetried[0]) {
+                                                log.warn("Not retrying a second deadline: {}",
+                                                         t.getMessage(), t);
+                                                throw HgStoreClientException.of(
+                                                        t.getMessage(), t);
+                                            }
+                                            deadlineRetried[0] = true;
+                                            log.warn("Deadline exceeded, retrying once in " +
+                                                     "case the partition leader moved: {}",
+                                                     t.getMessage());
                                         }
                                         if (i + 1 > NODE_MAX_RETRYING_TIMES) {
                                             log.error(maxTryMsg, t);
@@ -449,37 +467,51 @@ final class NodeTxExecutor {
     }
 
     /**
-     * Retry only failures that a fresh attempt can plausibly fix (a transport error, a
-     * leader change). A DEADLINE_EXCEEDED would wait the full deadline again, a CANCELLED
-     * means the caller's thread was interrupted; neither is retried, also when it is one of
-     * several failures of a parallel commit.
+     * How a failed attempt is treated by {@link #retryingInvoke}: FATAL is never retried (the
+     * caller's thread was interrupted, or the call was cancelled), DEADLINE is retried exactly
+     * once (the partition leader may have moved after the failed RPC invalidated the partition
+     * cache; a second deadline in a row would only wait the full deadline again on the same
+     * stalled store), everything else (transport errors, NOT_LEADER, store replacement) is
+     * retried up to NODE_MAX_RETRYING_TIMES as before. For a parallel commit the failures of
+     * the other partitions arrive as suppressed exceptions and are classified too; the most
+     * severe class wins.
      */
-    static boolean isRetryable(Throwable t) {
-        return isRetryable(t, Collections.newSetFromMap(new IdentityHashMap<>()));
+    enum Failure {
+        RETRYABLE, DEADLINE, FATAL
     }
 
-    private static boolean isRetryable(Throwable t, Set<Throwable> seen) {
+    static Failure classify(Throwable t) {
+        return classify(t, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    private static Failure classify(Throwable t, Set<Throwable> seen) {
+        Failure worst = Failure.RETRYABLE;
         Throwable c = t;
         while (c != null && seen.add(c)) {
             if (c instanceof InterruptedException) {
-                return false;
+                return Failure.FATAL;
             }
             if (c instanceof StatusRuntimeException) {
                 Status.Code code = ((StatusRuntimeException) c).getStatus().getCode();
-                if (code == Status.Code.DEADLINE_EXCEEDED || code == Status.Code.CANCELLED) {
-                    return false;
+                if (code == Status.Code.CANCELLED) {
+                    return Failure.FATAL;
+                }
+                if (code == Status.Code.DEADLINE_EXCEEDED) {
+                    worst = Failure.DEADLINE;
                 }
             }
-            // A parallel commit reports the other partitions' failures as suppressed;
-            // one non-retryable failure among them makes the whole attempt non-retryable.
             for (Throwable suppressed : c.getSuppressed()) {
-                if (!isRetryable(suppressed, seen)) {
-                    return false;
+                Failure f = classify(suppressed, seen);
+                if (f == Failure.FATAL) {
+                    return f;
+                }
+                if (f.compareTo(worst) > 0) {
+                    worst = f;
                 }
             }
             c = c.getCause();
         }
-        return true;
+        return worst;
     }
 
     private boolean isValid(Object obj) {

--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutor.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutor.java
@@ -46,6 +46,8 @@ import org.apache.hugegraph.store.client.util.HgStoreClientConst;
 import org.apache.hugegraph.store.term.HgPair;
 import org.apache.hugegraph.store.term.HgTriple;
 
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -376,30 +378,42 @@ final class NodeTxExecutor {
         return IntStream.rangeClosed(0, NODE_MAX_RETRYING_TIMES).boxed()
                         .map(
                                 i -> {
+                                    if (Thread.currentThread().isInterrupted()) {
+                                        // The caller (e.g. a REST worker hitting
+                                        // restserver.request_timeout) gave up: stop
+                                        // retrying instead of holding its thread.
+                                        throw HgStoreClientException.of(
+                                                "Interrupted before retry " + i);
+                                    }
                                     T buffer = null;
                                     try {
                                         buffer = supplier.get();
                                     } catch (Throwable t) {
-                                        if (i + 1 <= NODE_MAX_RETRYING_TIMES) {
-                                            try {
-                                                int sleepTime;
-                                                // The first three times try once every second
-                                                if (i < 3) {
-                                                    sleepTime = 1;
-                                                } else {
-                                                    // Subsequent incremental
-                                                    sleepTime = i - 1;
-                                                }
-                                                log.info("Waiting {} seconds " +
-                                                         "for the next try.",
-                                                         sleepTime);
-                                                Thread.sleep(sleepTime * 1000L);
-                                            } catch (InterruptedException e) {
-                                                log.error("Failed to sleep", e);
-                                            }
-                                        } else {
+                                        if (i + 1 > NODE_MAX_RETRYING_TIMES) {
                                             log.error(maxTryMsg, t);
                                             throw HgStoreClientException.of(
+                                                    t.getMessage(), t);
+                                        }
+                                        if (!isRetryable(t)) {
+                                            // A deadline or a cancellation will not
+                                            // get better by waiting the full deadline
+                                            // again; fail fast and let the caller decide.
+                                            log.warn("Not retrying after: {}",
+                                                     t.getMessage());
+                                            throw HgStoreClientException.of(
+                                                    t.getMessage(), t);
+                                        }
+                                        // The first three times try once every second,
+                                        // subsequent incremental
+                                        int sleepTime = i < 3 ? 1 : i - 1;
+                                        log.info("Waiting {} seconds for the next try.",
+                                                 sleepTime);
+                                        try {
+                                            Thread.sleep(sleepTime * 1000L);
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                            throw HgStoreClientException.of(
+                                                    "Interrupted while waiting to retry: " +
                                                     t.getMessage(), t);
                                         }
                                     }
@@ -409,6 +423,31 @@ final class NodeTxExecutor {
                         .filter(e -> e != null)
                         .findFirst();
 
+    }
+
+    /**
+     * Retry only failures that a fresh attempt can plausibly fix (a transport error, a
+     * leader change). A DEADLINE_EXCEEDED would wait the full deadline again, a CANCELLED
+     * means the caller's thread was interrupted; neither is retried.
+     */
+    static boolean isRetryable(Throwable t) {
+        Throwable c = t;
+        while (c != null) {
+            if (c instanceof InterruptedException) {
+                return false;
+            }
+            if (c instanceof StatusRuntimeException) {
+                Status.Code code = ((StatusRuntimeException) c).getStatus().getCode();
+                if (code == Status.Code.DEADLINE_EXCEEDED || code == Status.Code.CANCELLED) {
+                    return false;
+                }
+            }
+            if (c.getCause() == c) {
+                break;
+            }
+            c = c.getCause();
+        }
+        return true;
     }
 
     private boolean isValid(Object obj) {

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutorTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutorTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -40,7 +42,6 @@ import org.apache.hugegraph.store.client.type.HgStoreClientException;
 import org.junit.Test;
 
 import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 
 public class NodeTxExecutorTest {
 
@@ -131,7 +132,13 @@ public class NodeTxExecutorTest {
         assertFalse(NodeTxExecutor.isRetryable(new InterruptedException("interrupted")));
         // The status is usually wrapped by the time it reaches the retry loop
         assertFalse(NodeTxExecutor.isRetryable(HgStoreClientException.of(
-                "commit failed", new RuntimeException(Status.DEADLINE_EXCEEDED.asRuntimeException()))));
+                "commit failed",
+                new RuntimeException(Status.DEADLINE_EXCEEDED.asRuntimeException()))));
+        // one non-retryable failure among the suppressed ones decides
+        HgStoreClientException mixed = HgStoreClientException.of(
+                Status.UNAVAILABLE.asRuntimeException());
+        mixed.addSuppressed(Status.DEADLINE_EXCEEDED.asRuntimeException());
+        assertFalse(NodeTxExecutor.isRetryable(mixed));
         assertTrue(NodeTxExecutor.isRetryable(Status.UNAVAILABLE.asRuntimeException()));
         assertTrue(NodeTxExecutor.isRetryable(new RuntimeException("simulated transport failure")));
     }
@@ -185,5 +192,79 @@ public class NodeTxExecutorTest {
         });
         assertEquals("ok", result.get());
         assertEquals(2, attempts.get());
+    }
+
+    @Test
+    public void testInterruptBeforeCallSkipsTheAttempt() {
+        // restserver.request_timeout expired between two store calls of one request
+        NodeTxExecutor executor = NodeTxExecutor.graphOf("graph", null);
+        AtomicInteger attempts = new AtomicInteger();
+        try {
+            Thread.currentThread().interrupt();
+            assertThrows(HgStoreClientException.class, () ->
+                    executor.retryingInvoke(() -> {
+                        attempts.incrementAndGet();
+                        return "ok";
+                    }));
+            assertEquals(0, attempts.get());
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void testMixedCommitFailuresAreNotRetried() {
+        // One partition on a store being replaced (UNAVAILABLE, retryable), one on a stalled
+        // store (DEADLINE_EXCEEDED). Whichever finishes first, the commit must not be retried.
+        HgStoreSession unavailable = mock(HgStoreSession.class);
+        HgStoreSession stalled = mock(HgStoreSession.class);
+        when(unavailable.isTx()).thenReturn(true);
+        when(stalled.isTx()).thenReturn(true);
+        // fresh exceptions on every attempt, as the real gRPC calls produce them
+        org.mockito.Mockito.doAnswer(i -> {
+            throw new RuntimeException(HgStoreClientException.of(
+                    "commit", Status.UNAVAILABLE.asRuntimeException()));
+        }).when(unavailable).commit();
+        org.mockito.Mockito.doAnswer(i -> {
+            throw new RuntimeException(HgStoreClientException.of(
+                    "commit", Status.DEADLINE_EXCEEDED.asRuntimeException()));
+        }).when(stalled).commit();
+        List<HgStoreSession> sessions = Arrays.asList(unavailable, stalled);
+
+        NodeTxExecutor executor = NodeTxExecutor.graphOf("graph", null);
+        executor.setTx(true);
+        HgStoreClientException e = assertThrows(HgStoreClientException.class,
+                                                () -> executor.commitSessions(sessions));
+        assertEquals(1, e.getSuppressed().length);
+        assertFalse(NodeTxExecutor.isRetryable(e));
+        verify(unavailable).rollback();
+        verify(stalled).rollback();
+
+        AtomicInteger attempts = new AtomicInteger();
+        assertThrows(HgStoreClientException.class, () ->
+                executor.retryingInvoke(() -> {
+                    attempts.incrementAndGet();
+                    executor.commitSessions(sessions);
+                    return true;
+                }));
+        assertEquals(1, attempts.get());
+    }
+
+    @Test
+    public void testAllRetryableCommitFailuresAreRetried() {
+        HgStoreSession a = mock(HgStoreSession.class);
+        HgStoreSession b = mock(HgStoreSession.class);
+        when(a.isTx()).thenReturn(true);
+        when(b.isTx()).thenReturn(true);
+        org.mockito.Mockito.doThrow(new RuntimeException(Status.UNAVAILABLE.asRuntimeException()))
+                .when(a).commit();
+        org.mockito.Mockito.doThrow(new RuntimeException(Status.UNAVAILABLE.asRuntimeException()))
+                .when(b).commit();
+        NodeTxExecutor executor = NodeTxExecutor.graphOf("graph", null);
+        HgStoreClientException e = assertThrows(HgStoreClientException.class,
+                                                () -> executor.commitSessions(Arrays.asList(a, b)));
+        assertEquals(1, e.getSuppressed().length);
+        assertTrue(NodeTxExecutor.isRetryable(e));
     }
 }

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutorTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutorTest.java
@@ -18,7 +18,6 @@
 package org.apache.hugegraph.store.client;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -126,25 +125,32 @@ public class NodeTxExecutorTest {
     }
 
     @Test
-    public void testIsRetryableClassifiesFailures() {
-        assertFalse(NodeTxExecutor.isRetryable(Status.DEADLINE_EXCEEDED.asRuntimeException()));
-        assertFalse(NodeTxExecutor.isRetryable(Status.CANCELLED.asRuntimeException()));
-        assertFalse(NodeTxExecutor.isRetryable(new InterruptedException("interrupted")));
+    public void testClassifyFailures() {
+        assertEquals(NodeTxExecutor.Failure.DEADLINE,
+                     NodeTxExecutor.classify(Status.DEADLINE_EXCEEDED.asRuntimeException()));
+        assertEquals(NodeTxExecutor.Failure.FATAL,
+                     NodeTxExecutor.classify(Status.CANCELLED.asRuntimeException()));
+        assertEquals(NodeTxExecutor.Failure.FATAL,
+                     NodeTxExecutor.classify(new InterruptedException("interrupted")));
         // The status is usually wrapped by the time it reaches the retry loop
-        assertFalse(NodeTxExecutor.isRetryable(HgStoreClientException.of(
-                "commit failed",
-                new RuntimeException(Status.DEADLINE_EXCEEDED.asRuntimeException()))));
-        // one non-retryable failure among the suppressed ones decides
+        assertEquals(NodeTxExecutor.Failure.DEADLINE, NodeTxExecutor.classify(
+                HgStoreClientException.of("commit", new RuntimeException(
+                        Status.DEADLINE_EXCEEDED.asRuntimeException()))));
+        // The most severe class among the suppressed failures of a parallel commit wins
         HgStoreClientException mixed = HgStoreClientException.of(
                 Status.UNAVAILABLE.asRuntimeException());
         mixed.addSuppressed(Status.DEADLINE_EXCEEDED.asRuntimeException());
-        assertFalse(NodeTxExecutor.isRetryable(mixed));
-        assertTrue(NodeTxExecutor.isRetryable(Status.UNAVAILABLE.asRuntimeException()));
-        assertTrue(NodeTxExecutor.isRetryable(new RuntimeException("simulated transport failure")));
+        assertEquals(NodeTxExecutor.Failure.DEADLINE, NodeTxExecutor.classify(mixed));
+        mixed.addSuppressed(Status.CANCELLED.asRuntimeException());
+        assertEquals(NodeTxExecutor.Failure.FATAL, NodeTxExecutor.classify(mixed));
+        assertEquals(NodeTxExecutor.Failure.RETRYABLE,
+                     NodeTxExecutor.classify(Status.UNAVAILABLE.asRuntimeException()));
+        assertEquals(NodeTxExecutor.Failure.RETRYABLE,
+                     NodeTxExecutor.classify(new RuntimeException("simulated transport failure")));
     }
 
     @Test
-    public void testDeadlineExceededIsNotRetried() {
+    public void testDeadlineExceededIsRetriedExactlyOnce() {
         NodeTxExecutor executor = NodeTxExecutor.graphOf("graph", null);
         AtomicInteger attempts = new AtomicInteger();
         HgStoreClientException e = assertThrows(HgStoreClientException.class, () ->
@@ -153,8 +159,23 @@ public class NodeTxExecutorTest {
                     throw Status.DEADLINE_EXCEEDED.withDescription("deadline exceeded after 20s")
                                                   .asRuntimeException();
                 }));
-        assertEquals(1, attempts.get());
+        assertEquals(2, attempts.get());
         assertTrue(e.getMessage(), e.getMessage().contains("DEADLINE_EXCEEDED"));
+    }
+
+    @Test
+    public void testDeadlineThenNewLeaderSucceeds() {
+        // the failed RPC invalidates the partition cache; the single retry reaches the new leader
+        NodeTxExecutor executor = NodeTxExecutor.graphOf("graph", null);
+        AtomicInteger attempts = new AtomicInteger();
+        Optional<String> result = executor.retryingInvoke(() -> {
+            if (attempts.getAndIncrement() == 0) {
+                throw Status.DEADLINE_EXCEEDED.asRuntimeException();
+            }
+            return "ok";
+        });
+        assertEquals("ok", result.get());
+        assertEquals(2, attempts.get());
     }
 
     @Test
@@ -214,9 +235,9 @@ public class NodeTxExecutorTest {
     }
 
     @Test
-    public void testMixedCommitFailuresAreNotRetried() {
+    public void testMixedCommitFailuresAreRetriedExactlyOnce() {
         // One partition on a store being replaced (UNAVAILABLE, retryable), one on a stalled
-        // store (DEADLINE_EXCEEDED). Whichever finishes first, the commit must not be retried.
+        // store (DEADLINE_EXCEEDED). Whichever finishes first, the deadline decides: one retry.
         HgStoreSession unavailable = mock(HgStoreSession.class);
         HgStoreSession stalled = mock(HgStoreSession.class);
         when(unavailable.isTx()).thenReturn(true);
@@ -237,7 +258,7 @@ public class NodeTxExecutorTest {
         HgStoreClientException e = assertThrows(HgStoreClientException.class,
                                                 () -> executor.commitSessions(sessions));
         assertEquals(1, e.getSuppressed().length);
-        assertFalse(NodeTxExecutor.isRetryable(e));
+        assertEquals(NodeTxExecutor.Failure.DEADLINE, NodeTxExecutor.classify(e));
         verify(unavailable).rollback();
         verify(stalled).rollback();
 
@@ -248,7 +269,7 @@ public class NodeTxExecutorTest {
                     executor.commitSessions(sessions);
                     return true;
                 }));
-        assertEquals(1, attempts.get());
+        assertEquals(2, attempts.get());
     }
 
     @Test
@@ -265,6 +286,6 @@ public class NodeTxExecutorTest {
         HgStoreClientException e = assertThrows(HgStoreClientException.class,
                                                 () -> executor.commitSessions(Arrays.asList(a, b)));
         assertEquals(1, e.getSuppressed().length);
-        assertTrue(NodeTxExecutor.isRetryable(e));
+        assertEquals(NodeTxExecutor.Failure.RETRYABLE, NodeTxExecutor.classify(e));
     }
 }

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutorTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutorTest.java
@@ -17,7 +17,11 @@
 
 package org.apache.hugegraph.store.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,7 +36,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hugegraph.store.HgStoreSession;
+import org.apache.hugegraph.store.client.type.HgStoreClientException;
 import org.junit.Test;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 
 public class NodeTxExecutorTest {
 
@@ -114,5 +122,68 @@ public class NodeTxExecutorTest {
         } finally {
             workers.shutdownNow();
         }
+    }
+
+    @Test
+    public void testIsRetryableClassifiesFailures() {
+        assertFalse(NodeTxExecutor.isRetryable(Status.DEADLINE_EXCEEDED.asRuntimeException()));
+        assertFalse(NodeTxExecutor.isRetryable(Status.CANCELLED.asRuntimeException()));
+        assertFalse(NodeTxExecutor.isRetryable(new InterruptedException("interrupted")));
+        // The status is usually wrapped by the time it reaches the retry loop
+        assertFalse(NodeTxExecutor.isRetryable(HgStoreClientException.of(
+                "commit failed", new RuntimeException(Status.DEADLINE_EXCEEDED.asRuntimeException()))));
+        assertTrue(NodeTxExecutor.isRetryable(Status.UNAVAILABLE.asRuntimeException()));
+        assertTrue(NodeTxExecutor.isRetryable(new RuntimeException("simulated transport failure")));
+    }
+
+    @Test
+    public void testDeadlineExceededIsNotRetried() {
+        NodeTxExecutor executor = NodeTxExecutor.graphOf("graph", null);
+        AtomicInteger attempts = new AtomicInteger();
+        HgStoreClientException e = assertThrows(HgStoreClientException.class, () ->
+                executor.retryingInvoke(() -> {
+                    attempts.incrementAndGet();
+                    throw Status.DEADLINE_EXCEEDED.withDescription("deadline exceeded after 20s")
+                                                  .asRuntimeException();
+                }));
+        assertEquals(1, attempts.get());
+        assertTrue(e.getMessage(), e.getMessage().contains("DEADLINE_EXCEEDED"));
+    }
+
+    @Test
+    public void testInterruptStopsRetrying() {
+        // A REST worker hitting restserver.request_timeout (or a Gremlin evaluationTimeout)
+        // interrupts the calling thread while the store call is failing; the loop must
+        // stop instead of sleeping and retrying with the interrupt swallowed.
+        NodeTxExecutor executor = NodeTxExecutor.graphOf("graph", null);
+        AtomicInteger attempts = new AtomicInteger();
+        try {
+            assertThrows(HgStoreClientException.class, () ->
+                    executor.retryingInvoke(() -> {
+                        attempts.incrementAndGet();
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("simulated transport failure");
+                    }));
+            assertEquals(1, attempts.get());
+            assertTrue("interrupt flag must be restored for the caller",
+                       Thread.currentThread().isInterrupted());
+        } finally {
+            // clear the flag so the test runner thread is not left interrupted
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void testTransientFailureIsStillRetried() {
+        NodeTxExecutor executor = NodeTxExecutor.graphOf("graph", null);
+        AtomicInteger attempts = new AtomicInteger();
+        Optional<String> result = executor.retryingInvoke(() -> {
+            if (attempts.getAndIncrement() == 0) {
+                throw Status.UNAVAILABLE.withDescription("store replaced").asRuntimeException();
+            }
+            return "ok";
+        });
+        assertEquals("ok", result.get());
+        assertEquals(2, attempts.get());
     }
 }

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutorTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutorTest.java
@@ -186,7 +186,7 @@ public class NodeTxExecutorTest {
         NodeTxExecutor executor = NodeTxExecutor.graphOf("graph", null);
         AtomicInteger attempts = new AtomicInteger();
         try {
-            assertThrows(HgStoreClientException.class, () ->
+            HgStoreClientException e = assertThrows(HgStoreClientException.class, () ->
                     executor.retryingInvoke(() -> {
                         attempts.incrementAndGet();
                         Thread.currentThread().interrupt();
@@ -195,10 +195,21 @@ public class NodeTxExecutorTest {
             assertEquals(1, attempts.get());
             assertTrue("interrupt flag must be restored for the caller",
                        Thread.currentThread().isInterrupted());
+            // HugeException.isInterrupted() looks at the root cause
+            assertTrue(rootCause(e) instanceof InterruptedException);
+            assertEquals("simulated transport failure",
+                         rootCause(e).getSuppressed()[0].getMessage());
         } finally {
             // clear the flag so the test runner thread is not left interrupted
             Thread.interrupted();
         }
+    }
+
+    private static Throwable rootCause(Throwable t) {
+        while (t.getCause() != null && t.getCause() != t) {
+            t = t.getCause();
+        }
+        return t;
     }
 
     @Test
@@ -222,13 +233,14 @@ public class NodeTxExecutorTest {
         AtomicInteger attempts = new AtomicInteger();
         try {
             Thread.currentThread().interrupt();
-            assertThrows(HgStoreClientException.class, () ->
+            HgStoreClientException e = assertThrows(HgStoreClientException.class, () ->
                     executor.retryingInvoke(() -> {
                         attempts.incrementAndGet();
                         return "ok";
                     }));
             assertEquals(0, attempts.get());
             assertTrue(Thread.currentThread().isInterrupted());
+            assertTrue(rootCause(e) instanceof InterruptedException);
         } finally {
             Thread.interrupted();
         }

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutorTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/NodeTxExecutorTest.java
@@ -300,4 +300,25 @@ public class NodeTxExecutorTest {
         assertEquals(1, e.getSuppressed().length);
         assertEquals(NodeTxExecutor.Failure.RETRYABLE, NodeTxExecutor.classify(e));
     }
+
+    @Test
+    public void testDeadlineBudgetResetsAfterAnotherFailure() {
+        // deadline, then a transport error (leaders reloaded again), then a deadline:
+        // the two deadlines are not "in a row", so the second one is retried as well
+        NodeTxExecutor executor = NodeTxExecutor.graphOf("graph", null);
+        AtomicInteger attempts = new AtomicInteger();
+        Optional<String> result = executor.retryingInvoke(() -> {
+            switch (attempts.getAndIncrement()) {
+                case 0:
+                case 2:
+                    throw Status.DEADLINE_EXCEEDED.asRuntimeException();
+                case 1:
+                    throw Status.UNAVAILABLE.asRuntimeException();
+                default:
+                    return "ok";
+            }
+        });
+        assertEquals("ok", result.get());
+        assertEquals(4, attempts.get());
+    }
 }


### PR DESCRIPTION
## Purpose

Fixes #3199 by bounding HStore client retry latency and preserving cancellation/interrupt semantics when a store node stops responding.

![NodeTxExecutor retry flow](https://github.com/user-attachments/assets/a3db2ad4-4be0-4f8d-a2d0-47b7e578b82c)

Before this change, a stalled RPC could be retried up to 10 times. With `grpc.timeout.seconds=100`, repeated deadlines and backoff could hold one caller for about 19 minutes. `Thread.sleep` interruptions were swallowed, so REST `request_timeout` and Gremlin `evaluationTimeout` could not release the worker. Under load, one stalled store could exhaust the REST worker pool and cause cascading 503 responses.

## Core changes

- Classify failures across cause chains and suppressed parallel-commit failures:
  - `FATAL`: thread interrupt or `CANCELLED`; stop immediately, restore the interrupt flag, and keep `InterruptedException` as the root cause.
  - `DEADLINE`: `DEADLINE_EXCEEDED` may retry once so refreshed partition leaders can be used; the second deadline in the same call fails, even if other failures occur between them.
  - `RETRYABLE`: `UNAVAILABLE`, `NOT_LEADER`, and other transport failures retain the existing bounded-backoff retry behavior.
- Collect all parallel session failures and aggregate them with suppressed causes, so one racing partition cannot decide the retry path for the whole commit.
- Keep the existing retry count and backoff for retryable transport failures.

## Problem solved

- A stalled call is bounded to at most two RPC deadlines instead of up to 11.
- Request and evaluation interrupts can release the calling thread.
- Store-replacement and replicated-leader recovery remain retryable.
- Parallel-commit retry decisions are deterministic and retain all failure evidence.

## Verification

- `NodeTxExecutorTest`: 11/11 passed on Temurin 17.
- Exact-head command:
  ```bash
  mvn test -pl hugegraph-store/hg-store-test -am -P store-client-test -Dtest=NodeTxExecutorTest -DfailIfNoTests=false
  ```
- No public API or configuration change.